### PR TITLE
Fix Zygote error caused due to `fill!`

### DIFF
--- a/lib/Boltz/Project.toml
+++ b/lib/Boltz/Project.toml
@@ -1,10 +1,11 @@
 name = "Boltz"
 uuid = "4544d5e4-abc5-4dea-817f-29e4c205d9c8"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
@@ -17,6 +18,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 JLD2 = "0.4"
 Lux = "0.4"
 Metalhead = "0.7"
+ChainRulesCore = "1.15"
 NNlib = "0.8"
 julia = "1.7"
 

--- a/lib/Boltz/src/Boltz.jl
+++ b/lib/Boltz/src/Boltz.jl
@@ -13,6 +13,9 @@ using JLD2
 # We can automatically convert several Metalhead.jl models to Lux
 using Metalhead
 
+# Mark certain parts of layers as non-differentiable
+import ChainRulesCore
+
 # Utility Functions
 include("utils.jl")
 

--- a/lib/Boltz/src/vision/vit.jl
+++ b/lib/Boltz/src/vision/vit.jl
@@ -70,7 +70,7 @@ ClassTokens(dim::Int; init=Lux.zeros32) = ClassTokens(dim, init)
 Lux.initialparameters(rng::AbstractRNG, c::ClassTokens) = (token=c.init(rng, c.dim, 1, 1),)
 
 _fill_like(y::AbstractArray{T, 3}) where {T} = fill!(similar(y, 1, 1, size(y, 3)), one(T))
-NNlib.ChainRulesCore.@non_differentiable _fill_like(y)
+ChainRulesCore.@non_differentiable _fill_like(y)
 
 function (m::ClassTokens)(x::AbstractArray{T, 3}, ps, st) where {T}
     # Generic Alternative: Repeat is extremely inefficient on GPUs and even in general

--- a/lib/Boltz/src/vision/vit.jl
+++ b/lib/Boltz/src/vision/vit.jl
@@ -71,7 +71,7 @@ Lux.initialparameters(rng::AbstractRNG, c::ClassTokens) = (token=c.init(rng, c.d
 
 function (m::ClassTokens)(x::AbstractArray{T, 3}, ps, st) where {T}
     # Generic Alternative: Repeat is extremely inefficient on GPUs and even in general
-    tokens = ps.token .* fill!(similar(x, 1, 1, size(x, 3)), one(T))
+    tokens = ps.token .* fill(one(T), (1, 1, size(x, 3)))
     return hcat(tokens, x), st
 end
 

--- a/lib/Boltz/src/vision/vit.jl
+++ b/lib/Boltz/src/vision/vit.jl
@@ -69,9 +69,12 @@ ClassTokens(dim::Int; init=Lux.zeros32) = ClassTokens(dim, init)
 
 Lux.initialparameters(rng::AbstractRNG, c::ClassTokens) = (token=c.init(rng, c.dim, 1, 1),)
 
+_fill_like(y::AbstractArray{T, 3}) where {T} = fill!(similar(y, 1, 1, size(y, 3)), one(T))
+NNlib.ChainRulesCore.@non_differentiable _fill_like(y)
+
 function (m::ClassTokens)(x::AbstractArray{T, 3}, ps, st) where {T}
     # Generic Alternative: Repeat is extremely inefficient on GPUs and even in general
-    tokens = ps.token .* fill(one(T), (1, 1, size(x, 3)))
+    tokens = ps.token .* _fill_like(x)
     return hcat(tokens, x), st
 end
 


### PR DESCRIPTION
Zygote doesn't like the mutating `fill!`:

```julia
julia> Zygote.gradient(p -> sum(model(p, ps, st)[1]), x)
ERROR: Mutating arrays is not supported -- called setindex!(::Array{Float32, 3}, _...)
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] (::Zygote.var"#437#438"{Array{Float32, 3}})(#unused#::Nothing)
    @ Zygote ~/.julia/packages/Zygote/DkIUK/src/lib/array.jl:71
  [3] (::Zygote.var"#2357#back#439"{Zygote.var"#437#438"{Array{Float32, 3}}})(Δ::Nothing)
    @ Zygote ~/.julia/packages/ZygoteRules/AIbCs/src/adjoint.jl:67
  [4] Pullback
    @ ./array.jl:350 [inlined]
  [5] (::typeof(∂(fill!)))(Δ::Array{Float32, 3})
    @ Zygote ~/.julia/packages/Zygote/DkIUK/src/compiler/interface2.jl:0
  [6] Pullback
    @ ~/.julia/packages/Boltz/scRUZ/src/vision/vit.jl:74 [inlined]
  [7] (::typeof(∂(λ)))(Δ::Tuple{Array{Float32, 3}, Nothing})
    @ Zygote ~/.julia/packages/Zygote/DkIUK/src/compiler/interface2.jl:0
  [8] macro expansion
    @ ~/.julia/packages/Lux/0jReB/src/layers/basic.jl:0 [inlined]
  [9] Pullback
    @ ~/.julia/packages/Lux/0jReB/src/layers/basic.jl:523 [inlined]
 [10] (::typeof(∂(applychain)))(Δ::Tuple{FillArrays.Fill{Float32, 2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}, Nothing})
    @ Zygote ~/.julia/packages/Zygote/DkIUK/src/compiler/interface2.jl:0
 [11] Pullback
    @ ~/.julia/packages/Lux/0jReB/src/layers/basic.jl:520 [inlined]
 [12] (::typeof(∂(λ)))(Δ::Tuple{FillArrays.Fill{Float32, 2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}, Nothing})
    @ Zygote ~/.julia/packages/Zygote/DkIUK/src/compiler/interface2.jl:0
 [13] Pullback
    @ ./REPL[6]:1 [inlined]
 [14] (::typeof(∂(#7)))(Δ::Float32)
    @ Zygote ~/.julia/packages/Zygote/DkIUK/src/compiler/interface2.jl:0
 [15] (::Zygote.var"#52#53"{typeof(∂(#7))})(Δ::Float32)
    @ Zygote ~/.julia/packages/Zygote/DkIUK/src/compiler/interface.jl:41
 [16] gradient(f::Function, args::Array{Float32, 4})
    @ Zygote ~/.julia/packages/Zygote/DkIUK/src/compiler/interface.jl:76
 [17] top-level scope
    @ REPL[6]:1
 [18] top-level scope
    @ ~/.julia/packages/CUDA/GGwVa/src/initialization.jl:52
```

So this is a version using `fill` instead. Sister issue of https://github.com/FluxML/Metalhead.jl/pull/162