### PR TITLE
fix quickstart example

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -65,7 +65,7 @@ y, st = Lux.apply(model, x, ps, st)
 # Gradients
 ## Pullback API to capture change in state
 (l, st_), pb = pullback(p -> Lux.apply(model, x, p, st), ps)
-gs = pb((one.(l), nothing))
+gs = pb((one.(l), nothing))[1]
 
 # Optimization
 st_opt = Optimisers.setup(Optimisers.ADAM(0.0001), ps)


### PR DESCRIPTION
Without this, `gs` is a size 1 Tuple with a NamedTuple inside, which give this error on `Optimisers.update`: `type Tuple has no field layer_1`.
So I add `[1]` just like is done in other examples.