### PR TITLE
Add tip to install packages

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,6 +38,11 @@ Pkg.add("Lux")
 
 # Quickstart
 
+!!! tip
+    You need to install `Optimisers` and `Zygote` if not done already.
+
+    `Pkg.add(["Optimisers", "Zygote"])`
+
 ```julia
 using Lux, Random, Optimisers, Zygote
 ```


### PR DESCRIPTION
This PR closes issue #75 
Code blocks inside `Tip` is not allowed so i just used back-ticks (`)
Please let me know for any changes that i should take care

Currently site renders as shown below -->
![Capture](https://user-images.githubusercontent.com/43430490/175802054-8e1101aa-b4a0-4c26-8f10-d26f0db0451d.PNG)
.