### PR TITLE
add init_hidden_state function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lux"
 uuid = "b2108857-7c20-44ae-9111-449ecde12c47"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.4.9"
+version = "0.4.10"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -72,7 +72,7 @@ function (rnn::RNNCell)(x::AbstractMatrix, ps::Union{ComponentArray, NamedTuple}
                         st::NamedTuple)
     rng = replicate(st.rng)
     @set! st.rng = rng
-    hidden_state = rnn.init_state(rng, rnn.out_dims, size(x, 2))
+    hidden_state = init_hidden_state(rng, rnn, x)
     return rnn((x, hidden_state), ps, st)
 end
 
@@ -206,8 +206,8 @@ function (lstm::LSTMCell)(x::AbstractMatrix, ps::Union{ComponentArray, NamedTupl
                           st::NamedTuple)
     rng = replicate(st.rng)
     @set! st.rng = rng
-    hidden_state = lstm.init_state(rng, lstm.out_dims, size(x, 2))
-    memory = lstm.init_state(rng, lstm.out_dims, size(x, 2))
+    hidden_state = init_hidden_state(rng, lstm, x)
+    memory = init_hidden_state(rng, lstm, x)
     return lstm((x, hidden_state, memory), ps, st)
 end
 
@@ -312,7 +312,7 @@ function (gru::GRUCell)(x::AbstractMatrix, ps::Union{ComponentArray, NamedTuple}
                         st::NamedTuple)
     rng = replicate(st.rng)
     @set! st.rng = rng
-    hidden_state = gru.init_state(rng, gru.out_dims, size(x, 2))
+    hidden_state = init_hidden_state(rng, gru, x)
     return gru((x, hidden_state), ps, st)
 end
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -72,7 +72,7 @@ function (rnn::RNNCell)(x::AbstractMatrix, ps::Union{ComponentArray, NamedTuple}
                         st::NamedTuple)
     rng = replicate(st.rng)
     @set! st.rng = rng
-    hidden_state = init_hidden_state(rng, rnn, x)
+    hidden_state = _init_hidden_state(rng, rnn, x)
     return rnn((x, hidden_state), ps, st)
 end
 
@@ -206,8 +206,8 @@ function (lstm::LSTMCell)(x::AbstractMatrix, ps::Union{ComponentArray, NamedTupl
                           st::NamedTuple)
     rng = replicate(st.rng)
     @set! st.rng = rng
-    hidden_state = init_hidden_state(rng, lstm, x)
-    memory = init_hidden_state(rng, lstm, x)
+    hidden_state = _init_hidden_state(rng, lstm, x)
+    memory = _init_hidden_state(rng, lstm, x)
     return lstm((x, hidden_state, memory), ps, st)
 end
 
@@ -312,7 +312,7 @@ function (gru::GRUCell)(x::AbstractMatrix, ps::Union{ComponentArray, NamedTuple}
                         st::NamedTuple)
     rng = replicate(st.rng)
     @set! st.rng = rng
-    hidden_state = init_hidden_state(rng, gru, x)
+    hidden_state = _init_hidden_state(rng, gru, x)
     return gru((x, hidden_state), ps, st)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -194,11 +194,16 @@ end
 @inline _gate(h::Int, n::Int) = (1:h) .+ h * (n - 1)
 @inline _gate(x::AbstractVector, h::Int, n::Int) = view(x, _gate(h, n))
 @inline _gate(x::AbstractMatrix, h::Int, n::Int) = view(x, _gate(h, n), :)
-@inline init_hidden_state(rng::AbstractRNG, rnn, x::AbstractMatrix) =
-    rnn.init_state(rng, rnn.out_dims, size(x, 2))
-@inline init_hidden_state(rng::AbstractRNG, rnn, x::Union{CUDA.StridedSubCuArray, CuArray}) =
-    rnn.init_state(rng, rnn.out_dims, size(x, 2)) |> gpu
-    
+
+@inline function init_hidden_state(rng::AbstractRNG, rnn, x::AbstractMatrix)
+    return rnn.init_state(rng, rnn.out_dims, size(x, 2))
+end
+
+@inline function init_hidden_state(rng::AbstractRNG, rnn,
+                                   x::Union{CUDA.StridedSubCuArray, CuArray})
+    return rnn.init_state(rng, rnn.out_dims, size(x, 2)) |> gpu
+end
+
 """
     multigate(x::AbstractArray, ::Val{N})
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -195,11 +195,11 @@ end
 @inline _gate(x::AbstractVector, h::Int, n::Int) = view(x, _gate(h, n))
 @inline _gate(x::AbstractMatrix, h::Int, n::Int) = view(x, _gate(h, n), :)
 
-@inline function init_hidden_state(rng::AbstractRNG, rnn, x::AbstractMatrix)
+@inline function _init_hidden_state(rng::AbstractRNG, rnn, x::AbstractMatrix)
     return rnn.init_state(rng, rnn.out_dims, size(x, 2))
 end
 
-@inline function init_hidden_state(rng::AbstractRNG, rnn,
+@inline function _init_hidden_state(rng::AbstractRNG, rnn,
                                    x::Union{CUDA.StridedSubCuArray, CuArray})
     return rnn.init_state(rng, rnn.out_dims, size(x, 2)) |> gpu
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -201,7 +201,7 @@ end
 
 @inline function _init_hidden_state(rng::AbstractRNG, rnn,
                                     x::Union{CUDA.StridedSubCuArray, CuArray})
-    return rnn.init_state(rng, rnn.out_dims, size(x, 2)) |> gpu
+    return CuArray(rnn.init_state(rng, rnn.out_dims, size(x, 2)))
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -194,6 +194,8 @@ end
 @inline _gate(h::Int, n::Int) = (1:h) .+ h * (n - 1)
 @inline _gate(x::AbstractVector, h::Int, n::Int) = view(x, _gate(h, n))
 @inline _gate(x::AbstractMatrix, h::Int, n::Int) = view(x, _gate(h, n), :)
+@inline init_hidden_state(rng::AbstractRNG, rnn, x::AbstractMatrix) = rnn.init_state(rng, rnn.out_dims, size(x, 2))
+@inline init_hidden_state(rng::AbstractRNG, rnn, x::CUDA.StridedSubCuArray) = rnn.init_state(rng, rnn.out_dims, size(x, 2)) |> gpu
 
 """
     multigate(x::AbstractArray, ::Val{N})

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -194,9 +194,11 @@ end
 @inline _gate(h::Int, n::Int) = (1:h) .+ h * (n - 1)
 @inline _gate(x::AbstractVector, h::Int, n::Int) = view(x, _gate(h, n))
 @inline _gate(x::AbstractMatrix, h::Int, n::Int) = view(x, _gate(h, n), :)
-@inline init_hidden_state(rng::AbstractRNG, rnn, x::AbstractMatrix) = rnn.init_state(rng, rnn.out_dims, size(x, 2))
-@inline init_hidden_state(rng::AbstractRNG, rnn, x::CUDA.StridedSubCuArray) = rnn.init_state(rng, rnn.out_dims, size(x, 2)) |> gpu
-
+@inline init_hidden_state(rng::AbstractRNG, rnn, x::AbstractMatrix) =
+    rnn.init_state(rng, rnn.out_dims, size(x, 2))
+@inline init_hidden_state(rng::AbstractRNG, rnn, x::Union{CUDA.StridedSubCuArray, CuArray}) =
+    rnn.init_state(rng, rnn.out_dims, size(x, 2)) |> gpu
+    
 """
     multigate(x::AbstractArray, ::Val{N})
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -200,7 +200,7 @@ end
 end
 
 @inline function _init_hidden_state(rng::AbstractRNG, rnn,
-                                   x::Union{CUDA.StridedSubCuArray, CuArray})
+                                    x::Union{CUDA.StridedSubCuArray, CuArray})
     return rnn.init_state(rng, rnn.out_dims, size(x, 2)) |> gpu
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -96,3 +96,14 @@ end
         @test_nowarn Optimisers.update!(st_opt, ps_c, ps_c)
     end
 end
+
+@testset "_init_hidden_state" begin
+    rnn = RNNCell(3 => 5, init_state=ones32)
+    x = randn(rng, Float32, 3, 2, 2)
+    @test _init_hidden_state(rng, rnn, view(x, :, 1, :)) == zeros(Float32, 5, 2)
+    
+    if CUDA.functional()
+        x = x |> gpu
+        @test _init_hidden_state(rng, rnn, view(x, :, 1, :)) == CUDA.zeros(Float32, 5, 2)
+    end
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -98,12 +98,12 @@ end
 end
 
 @testset "_init_hidden_state" begin
-    rnn = RNNCell(3 => 5, init_state=ones32)
+    rnn = RNNCell(3 => 5, init_state=Lux.zeros32)
     x = randn(rng, Float32, 3, 2, 2)
-    @test _init_hidden_state(rng, rnn, view(x, :, 1, :)) == zeros(Float32, 5, 2)
+    @test Lux._init_hidden_state(rng, rnn, view(x, :, 1, :)) == zeros(Float32, 5, 2)
     
     if CUDA.functional()
         x = x |> gpu
-        @test _init_hidden_state(rng, rnn, view(x, :, 1, :)) == CUDA.zeros(Float32, 5, 2)
+        @test Lux._init_hidden_state(rng, rnn, view(x, :, 1, :)) == CUDA.zeros(Float32, 5, 2)
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -98,12 +98,13 @@ end
 end
 
 @testset "_init_hidden_state" begin
-    rnn = RNNCell(3 => 5, init_state=Lux.zeros32)
+    rnn = RNNCell(3 => 5; init_state=Lux.zeros32)
     x = randn(rng, Float32, 3, 2, 2)
     @test Lux._init_hidden_state(rng, rnn, view(x, :, 1, :)) == zeros(Float32, 5, 2)
-    
+
     if CUDA.functional()
         x = x |> gpu
-        @test Lux._init_hidden_state(rng, rnn, view(x, :, 1, :)) == CUDA.zeros(Float32, 5, 2)
+        @test Lux._init_hidden_state(rng, rnn, view(x, :, 1, :)) ==
+              CUDA.zeros(Float32, 5, 2)
     end
 end


### PR DESCRIPTION
This is a possible simple patch for https://github.com/avik-pal/Lux.jl/issues/100, although I don't know if it is the best.

Initially, I tried to dispatch over `CuArrays` but then I noticed that their views weren't caught by that, so eventually I dispatched over `CUDA.StridedSubCuArray`, which works but I don't know if there is a better solution.

Passing the `init_state` through `gpu` would work for any `init_state`, but maybe in the case of the default state initialization, which is zeros, would it be better to initialize it with CUDA.zeros to save some allocations?

Also, I'm not sure if I have to do something with `rng` (like `replicate` it and `@set!` it) or if just passing it to `init_state` is enough.