### PR TITLE
Fmappable models

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
   - "Manual":
       - "Lux Interface": "manual/interface.md"
       - "Migrating from Flux to Lux": "manual/migrate_from_flux.md"
+      - "Freezing Parameters of a Model": "manual/freezing_parameters.md"
   - "API Reference":
       - "Layers": "api/layers.md"
       - "Functional": "api/functional.md"

--- a/docs/src/api/contrib.md
+++ b/docs/src/api/contrib.md
@@ -32,12 +32,34 @@ Lux.Training.compute_gradients
 Lux.Training.apply_gradients
 ```
 
+For detailed usage example look at
+[this tutorial](../examples/generated/beginner/PolynomialFitting/main.md).
+
 ### Why VJP rules when we already have [AbstractDifferentiation.jl](https://github.com/JuliaDiff/AbstractDifferentiation.jl/)?
 
 In the long term, the goal is to just use AD.jl directly. However, there are current
 refactors being planned (See [this issue](https://github.com/EnzymeAD/Enzyme.jl/issues/349#issuecomment-1144514285)).
 Once the package is stable and we have the necessary backend support, we will be dropping
 the VJP rules in this module.
+
+## Parameter Freezing
+
+!!! note
+    In the long term, this will be supported via
+    [Optimisers.jl](https://github.com/FluxML/Optimisers.jl/pull/49).
+
+```@docs
+Lux.FrozenLayer
+Lux.freeze
+```
+
+For detailed usage example look at the [manual page](../manual/freezing_parameters.md).
+
+## Fmap on Lux Models
+
+```@docs
+Lux.model_map
+```
 
 ## Index
 

--- a/docs/src/examples/examples.md
+++ b/docs/src/examples/examples.md
@@ -3,6 +3,7 @@
 ## Tutorials
 
 - [Julia & Lux for the Uninitiated](generated/beginner/Basics/main.md)
+- [Fitting a Simple Polynomial](generated/beginner/PolynomialFitting/main.md)
 - [Training a Simple LSTM](generated/beginner/SimpleRNN/main.md)
 - [MNIST Classification using NeuralODE](generated/intermediate/NeuralODE/main.md)
 - [Bayesian Neural Network](generated/intermediate/BayesianNN/main.md)

--- a/docs/src/manual/freezing_parameters.md
+++ b/docs/src/manual/freezing_parameters.md
@@ -1,0 +1,101 @@
+# Freezing Model Parameters
+
+!!! warning
+
+    API for freezing parameters should be considered experimental at this point.
+
+In this manual we will go over how to freeze certain parameters in a model.
+
+## Freezing layers of a particular kind
+
+To freeze a particular kind of layer, let's say [`Dense`](@ref) in the following example.
+We can use the [`Lux.model_map`](@ref) function and freeze layers if they are of type
+`Dense`.
+
+```@example
+import Lux, Random
+
+rng = Random.default_rng()
+Random.seed!(rng, 0)
+
+model = Lux.Chain(Lux.Dense(3, 4), Lux.Chain(Lux.Dense(4, 4), Lux.Dropout(0.5f0),
+                                             Lux.BatchNorm(4)),
+                  Lux.Dense(4, 1); disable_optimizations=true)
+
+ps, st = Lux.setup(rng, model)
+
+x = randn(rng, Float32, 3, 2)
+
+model(x, ps, st)
+
+function freeze_dense(d::Lux.Dense, ps, st, name::String)
+    return Lux.freeze(d, ps, st, (:weight, :bias))
+end
+freeze_dense(l, ps, st, name) = (l, ps, st)
+
+model_frozen, ps_frozen, st_frozen = Lux.model_map(freeze_dense, model, ps, st, "model")
+
+model_frozen(x, ps_frozen, st_frozen)
+```
+
+## Freezing by layer name
+
+When the function in `model_map` is called, the 4th argument is the name of the layer.
+For example, if you want to freeze the 1st layer inside the inner Chain. The name for this
+would be `<model>.layer_2.layer_1`.
+
+
+```@raw html
+=== "Freezing by layer name"
+
+    ```julia
+    function freeze_by_name(d, ps, st, name::String)
+        if name == "model.layer_2.layer_1"
+            return Lux.freeze(d, ps, st, (:weight, :bias))
+        else
+            return d, ps, st
+        end
+    end
+    ```
+
+=== "Freezing by layer type"
+
+    ```julia
+    function freeze_dense(d::Lux.Dense, ps, st, name::String)
+        return Lux.freeze(d, ps, st, (:weight, :bias))
+    end
+    freeze_dense(l, ps, st, name) = (l, ps, st)
+    ```
+```
+
+## Freezing part of the parameters
+
+Instead of freezing all the parameters, we can simple specify `(:weight,)` to freeze only
+the `weight` parameter while training the `bias` parameter.
+
+
+```@raw html
+=== "Freezing some parameters of a layer"
+
+    ```julia hl_lines="3"
+    function freeze_by_name(d, ps, st, name::String)
+        if name == "model.layer_2.layer_1"
+            return Lux.freeze(d, ps, st, (:weight,))
+        else
+            return d, ps, st
+        end
+    end
+    ```
+
+=== "Freezing all parameters of a layer"
+
+    ```julia
+    function freeze_by_name(d, ps, st, name::String)
+        if name == "model.layer_2.layer_1"
+            return Lux.freeze(d, ps, st, (:weight, :bias))
+        else
+            return d, ps, st
+        end
+    end
+    ```
+```

--- a/src/Lux.jl
+++ b/src/Lux.jl
@@ -49,6 +49,8 @@ end
 
 # Experimental
 include("contrib/training.jl")
+include("contrib/freeze.jl")
+include("contrib/functor.jl")
 
 # Deprecations
 include("deprecated.jl")

--- a/src/contrib/freeze.jl
+++ b/src/contrib/freeze.jl
@@ -1,0 +1,104 @@
+"""
+    FrozenLayer(l::AbstractExplicitLayer, which_params::Tuple)
+
+Freeze the parameters with name `which_params` of the layer `l`.
+
+## Arguments
+
+  - `l`: Lux AbstractExplicitLayer.
+  - `which_params`: Parameter Names to be Frozen.
+
+## Input
+
+  - `x`: Input to the layer `l`.
+
+## Returns
+
+  - Output of the inner layer `l`
+  - Updated State
+
+## Parameters
+
+  - Parameters of the layer `l` excluding `which_params`.
+
+## States
+
+  - `frozen_params`: Parameters that are frozen, i.e., `which_params`.
+  - `states`: The state of the inner layer `l`.
+
+## Example
+
+```julia
+m = Lux.FrozenLayer(Lux.Dense(2 => 2), (:weight,))
+```
+
+See also [`Lux.freeze`](@ref).
+"""
+struct FrozenLayer{which_params, L <: AbstractExplicitLayer} <: AbstractExplicitLayer
+    layer::L
+
+    function FrozenLayer(l::AbstractExplicitLayer, which_params::Tuple)
+        return new{which_params, typeof(l)}(l)
+    end
+end
+
+function initialparameters(rng::AbstractRNG,
+                           l::FrozenLayer{which_params}) where {which_params}
+    ps = initialparameters(rng, l.layer)
+    ps_trainable = []
+    for (k, v) in pairs(ps)
+        k in which_params && continue
+        push!(ps_trainable, k => v)
+    end
+    return (; ps_trainable...)
+end
+
+function initialstates(rng::AbstractRNG, l::FrozenLayer{which_params}) where {which_params}
+    ps = initialparameters(rng, l.layer)
+    st = initialstates(rng, l.layer)
+    ps_frozen = []
+    for (k, v) in pairs(ps)
+        !(k in which_params) && continue
+        push!(ps_frozen, k => v)
+    end
+    return (frozen_params=(; ps_frozen...), states=st)
+end
+
+function (f::FrozenLayer)(x, ps, st::NamedTuple)
+    y, st_ = f.layer(x, merge(ps, st.frozen_params), st.states)
+    st = merge(st, (; states=st_))
+    return y, st
+end
+
+function Base.show(io::IO, f::FrozenLayer{which_params}) where {which_params}
+    wp = join(map(x -> "`$(x)`", which_params), ", ", " & ")
+    return print(io, f.layer, " (with ", wp, " frozen)")
+end
+
+"""
+    freeze(l::AbstractExplicitLayer, which_params::Tuple)
+
+Constructs a version of `l` with `which_params` frozen.
+"""
+freeze(l::AbstractExplicitLayer, which_params::Tuple) = FrozenLayer(l, which_params)
+
+"""
+    freeze(l::AbstractExplicitLayer, ps, st::NamedTuple, which_params::Tuple)
+
+Construct a [`Lux.FrozenLayer`](@ref) for `l` with the current parameters and states.
+"""
+function freeze(l::AbstractExplicitLayer, ps, st::NamedTuple, which_params::Tuple)
+    fl = FrozenLayer(l, which_params)
+    ps_frozen = []
+    ps_trainable = []
+    for (k, v) in pairs(ps)
+        if k in which_params
+            push!(ps_frozen, k => v)
+        else
+            push!(ps_trainable, k => v)
+        end
+    end
+    ps = (; ps_trainable...)
+    st = (frozen_params=(; ps_frozen...), states=st)
+    return fl, ps, st
+end

--- a/src/contrib/functor.jl
+++ b/src/contrib/functor.jl
@@ -1,0 +1,38 @@
+"""
+    model_map(f::Function, l::AbstractExplicitLayer, ps, st::NamedTuple,
+              name::String="model")
+
+Map the function `f` over the model `l`, with the parameters `ps` and states `st`. This is
+different from `Functors.fmap` since it zips the layers, parameters, and states and invokes
+the function on all of them together.
+"""
+function model_map(f::Function, l::AbstractExplicitLayer, ps, st::NamedTuple,
+                   name::String="model")
+    l_c, l_re = Functors.functor(l)
+    ps_c, ps_re = Functors.functor(ps)
+    st_c, st_re = Functors.functor(st)
+
+    length(l_c) == 0 && return f(l, ps, st, name)
+
+    l_c_ = l_c isa Tuple ? l_c[1] : l_c
+    ks = keys(l_c_)
+
+    l_c_new, ps_c_new, st_c_new = [], [], []
+    for k in ks
+        l_c_new_, ps_c_new_, st_c_new_ = model_map(f, getproperty(l_c_, k),
+                                                   getproperty(ps_c, k),
+                                                   getproperty(st_c, k),
+                                                   join((name, k), "."))
+        push!(l_c_new, k => l_c_new_)
+        push!(ps_c_new, k => ps_c_new_)
+        push!(st_c_new, k => st_c_new_)
+    end
+    l_c_new = (; l_c_new...)
+    l_c_new = l_c isa Tuple ? (l_c_new,) : l_c_new
+
+    l_new = l_re(l_c_new)
+    ps_new = ps_re((; ps_c_new...))
+    st_new = st_re((; st_c_new...))
+
+    return l_new, ps_new, st_new
+end

--- a/src/core.jl
+++ b/src/core.jl
@@ -125,6 +125,19 @@ function statelength(l::AbstractExplicitContainerLayer{layers}) where {layers}
     return sum(statelength, getfield.((l,), layers))
 end
 
+function Functors.functor(::Type{<:AbstractExplicitContainerLayer},
+                          x::AbstractExplicitContainerLayer{layers}) where {layers}
+    _children = getproperty.((x,), layers)
+    function layer_reconstructor(z)
+        l = x
+        for (child, name) in zip(z, layers)
+            l = Setfield.set(l, Setfield.PropertyLens{name}(), child)
+        end
+        return l
+    end
+    return _children, layer_reconstructor
+end
+
 # Test Mode
 """
     testmode(st::NamedTuple)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -469,6 +469,7 @@ struct Chain{T} <: AbstractExplicitContainerLayer{(:layers,)}
     function Chain(xs::AbstractVector; disable_optimizations::Bool=false)
         return Chain(xs...; disable_optimizations)
     end
+    Chain(nt::NamedTuple) = new{typeof(nt)}(nt)
 end
 
 function flatten_model(layers::Union{AbstractVector, Tuple})


### PR DESCRIPTION
#144 pulls out some of the features from this PR. Need to update this PR only to tackle the parameter freezing component.

TODOs:
- [x] We can fmap over models now
- [x] API to freeze models
- [x] Documentation
- [ ] Tests
- [x] Descend into model, parameters and states together (`Lux.model_map` function)
- [ ] Documentation on how to freeze a sequence of layers

Fixes #111 