### PR TITLE
Rnn bias deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v0.4
 
+## v0.4.14
+  - Deprecate `bias` in favor of `use_bias` for `RNNCell`.
+
 ## v0.4.12
 
   - Deprecate `bias` in favor of `use_bias` for `Dense` and `Scale`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lux"
 uuid = "b2108857-7c20-44ae-9111-449ecde12c47"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.4.13"
+version = "0.4.14"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -49,6 +49,7 @@ end
 function RNNCell((in_dims, out_dims)::Pair{<:Int, <:Int}, activation=tanh;
                  use_bias::Bool=true, bias::Union{Missing, Bool}=missing, init_bias=zeros32,
                  init_weight=glorot_uniform, init_state=ones32)
+    # Deprecated Functionality (Remove in v0.5)
     if !ismissing(bias)
         Base.depwarn("`bias` argument to `RNNCell` has been deprecated and will be removed" *
                      " in v0.5. Use `use_bias` kwarg instead.", :RNNCell)

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -79,8 +79,7 @@ function initialstates(rng::AbstractRNG, ::RNNCell)
     return (rng=replicate(rng),)
 end
 
-function (rnn::RNNCell)(x::AbstractMatrix, ps::Union{ComponentArray, NamedTuple},
-                        st::NamedTuple)
+function (rnn::RNNCell)(x::AbstractMatrix, ps, st::NamedTuple)
     rng = replicate(st.rng)
     @set! st.rng = rng
     hidden_state = _init_hidden_state(rng, rnn, x)
@@ -88,22 +87,20 @@ function (rnn::RNNCell)(x::AbstractMatrix, ps::Union{ComponentArray, NamedTuple}
 end
 
 function (rnn::RNNCell{true})((x, hidden_state)::Tuple{<:AbstractMatrix, <:AbstractMatrix},
-                              ps::Union{ComponentArray, NamedTuple}, st::NamedTuple)
+                              ps, st::NamedTuple)
     h_new = rnn.activation.(ps.weight_ih * x .+ ps.weight_hh * hidden_state .+ ps.bias)
     return h_new, st
 end
 
-function (rnn::RNNCell{true, typeof(identity)})((x,
-                                                 hidden_state)::Tuple{<:AbstractMatrix,
-                                                                      <:AbstractMatrix},
-                                                ps::Union{ComponentArray, NamedTuple},
-                                                st::NamedTuple)
+function (rnn::RNNCell{true, typeof(identity)})((x, hidden_state)::Tuple{<:AbstractMatrix,
+                                                                         <:AbstractMatrix},
+                                                ps, st::NamedTuple)
     h_new = ps.weight_ih * x .+ ps.weight_hh * hidden_state .+ ps.bias
     return h_new, st
 end
 
 function (rnn::RNNCell{false})((x, hidden_state)::Tuple{<:AbstractMatrix, <:AbstractMatrix},
-                               ps::Union{ComponentArray, NamedTuple}, st::NamedTuple)
+                               ps, st::NamedTuple)
     h_new = rnn.activation.(ps.weight_ih * x .+ ps.weight_hh * hidden_state)
     return h_new, st
 end
@@ -111,8 +108,7 @@ end
 function (rnn::RNNCell{false, typeof(identity)})((x,
                                                   hidden_state)::Tuple{<:AbstractMatrix,
                                                                        <:AbstractMatrix},
-                                                 ps::Union{ComponentArray, NamedTuple},
-                                                 st::NamedTuple)
+                                                 ps, st::NamedTuple)
     h_new = ps.weight_ih * x .+ ps.weight_hh * hidden_state
     return h_new, st
 end

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -116,7 +116,7 @@ end
 function Base.show(io::IO, r::RNNCell{use_bias}) where {use_bias}
     print(io, "RNNCell($(r.in_dims) => $(r.out_dims)")
     (r.activation == identity) || print(io, ", $(r.activation)")
-    use_bias || print(io, ", use_bias=false")
+    use_bias || print(io, ", bias=false")
     return print(io, ")")
 end
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -92,9 +92,10 @@ function (rnn::RNNCell{true})((x, hidden_state)::Tuple{<:AbstractMatrix, <:Abstr
     return h_new, st
 end
 
-function (rnn::RNNCell{true, typeof(identity)})((x, hidden_state)::Tuple{<:AbstractMatrix,
-                                                                         <:AbstractMatrix},
-                                                ps, st::NamedTuple)
+function (rnn::RNNCell{true, typeof(identity)})((x,
+                                                 hidden_state)::Tuple{<:AbstractMatrix,
+                                                                      <:AbstractMatrix}, ps,
+                                                st::NamedTuple)
     h_new = ps.weight_ih * x .+ ps.weight_hh * hidden_state .+ ps.bias
     return h_new, st
 end

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -49,7 +49,6 @@ end
 function RNNCell((in_dims, out_dims)::Pair{<:Int, <:Int}, activation=tanh;
                  use_bias::Bool=true, bias::Union{Missing, Bool}=missing, init_bias=zeros32,
                  init_weight=glorot_uniform, init_state=ones32)
-
     if !ismissing(bias)
         Base.depwarn("`bias` argument to `RNNCell` has been deprecated and will be removed" *
                      " in v0.5. Use `use_bias` kwarg instead.", :RNNCell)
@@ -61,8 +60,8 @@ function RNNCell((in_dims, out_dims)::Pair{<:Int, <:Int}, activation=tanh;
     end
 
     return RNNCell{use_bias, typeof(activation), typeof(init_bias), typeof(init_weight),
-                   typeof(init_state)}(activation, in_dims, out_dims, init_bias, init_weight,
-                                       init_state)
+                   typeof(init_state)}(activation, in_dims, out_dims, init_bias,
+                                       init_weight, init_state)
 end
 
 function initialparameters(rng::AbstractRNG, rnn::RNNCell{use_bias}) where {use_bias}

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -1,4 +1,4 @@
-using JET, Lux, Random, Test
+using JET, Lux, NNlib, Random, Test
 
 include("../test_utils.jl")
 

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -5,27 +5,35 @@ include("../test_utils.jl")
 rng = Random.default_rng()
 Random.seed!(rng, 0)
 
-@testset "RNNCell" begin for rnncell in (RNNCell(3 => 5, identity), RNNCell(3 => 5, tanh),
-                                         RNNCell(3 => 5, tanh; bias=false),
-                                         RNNCell(3 => 5, identity; bias=false))
-    println(rnncell)
-    ps, st = Lux.setup(rng, rnncell)
-    x = randn(rng, Float32, 3, 2)
-    h, st_ = Lux.apply(rnncell, x, ps, st)
+@testset "RNNCell" begin
+    for rnncell in (RNNCell(3 => 5, identity), RNNCell(3 => 5, tanh),
+                    RNNCell(3 => 5, tanh; use_bias=false),
+                    RNNCell(3 => 5, identity; use_bias=false))
+        println(rnncell)
+        ps, st = Lux.setup(rng, rnncell)
+        x = randn(rng, Float32, 3, 2)
+        h, st_ = Lux.apply(rnncell, x, ps, st)
 
-    run_JET_tests(rnncell, x, ps, st)
-    run_JET_tests(rnncell, (x, h), ps, st_)
+        run_JET_tests(rnncell, x, ps, st)
+        run_JET_tests(rnncell, (x, h), ps, st_)
 
-    function loss_loop_rnncell(p)
-        h, st_ = rnncell(x, p, st)
-        for i in 1:10
-            h, st_ = rnncell((x, h), p, st_)
+        function loss_loop_rnncell(p)
+            h, st_ = rnncell(x, p, st)
+            for i in 1:10
+                h, st_ = rnncell((x, h), p, st_)
+            end
+            return sum(abs2, h)
         end
-        return sum(abs2, h)
-    end
 
-    test_gradient_correctness_fdm(loss_loop_rnncell, ps; atol=1e-3, rtol=1e-3)
-end end
+        test_gradient_correctness_fdm(loss_loop_rnncell, ps; atol=1e-3, rtol=1e-3)
+    end
+    # Deprecated Functionality (Remove in v0.5)
+    @testset "Deprecations" begin
+        @test_deprecated RNNCell(3 => 5, relu; bias=false)
+        @test_deprecated RNNCell(3 => 5, relu; bias=true)
+        @test_throws ArgumentError RNNCell(3 => 5, relu; bias=false, use_bias=false)
+    end
+end
 
 @testset "LSTMCell" begin
     lstmcell = LSTMCell(3 => 5)


### PR DESCRIPTION
This PR deprecates RNNCell.bias to make it consistent with base.jl
In other ML frameworks it is possible to deactivate the bias of other recurrent layers as well (e.g. LSTM).
I could add a `use_bias` without `bias` to LSTM and GRU but I think in this case a deprecated `bias` would be a better choice so you get the same behavior for all the layers (i.e. you can create RNNCells and LSTMs with `bias`, which prints a warning)