### PR TITLE
LSTM docs: don't go over first element in sequence twice

### DIFF
--- a/docs/src/devdocs/layer_implementation.md
+++ b/docs/src/devdocs/layer_implementation.md
@@ -52,9 +52,10 @@ An example implementation would be
 
 ```julia
 function (l::LSTM)(x::AbstractArray{T,3}, ps::NamedTuple, st::NamedTuple) where {T}
-    (h, c), st = s.lstm_cell(view(x, :, 1, :), ps, st)
-    for i in 2:size(x, 2)
-        (h, c), st = s.lstm_cell((view(x, :, i, :), h, c), ps, st)
+    x_init, x_rest = Iterators.peel(eachslice(x, dims = 2))
+    (h, c), st = l.lstm_cell(x_init, ps, st)
+    for x in x_rest
+        (h, c), st = l.lstm_cell((x, h, c), ps, st)
     end
     return h, st
 end

--- a/docs/src/devdocs/layer_implementation.md
+++ b/docs/src/devdocs/layer_implementation.md
@@ -56,7 +56,7 @@ struct LSTM{L} <: Lux.AbstractExplicitContainerLayer{(:lstm_cell,)}
 end
 
 function (l::LSTM)(x::AbstractArray{T,3}, ps::NamedTuple, st::NamedTuple) where {T}
-    x_init, x_rest = Iterators.peel(eachslice(x, dims = 2))
+    x_init, x_rest = Iterators.peel(eachslice(x; dims=2))
     (h, c), st = l.lstm_cell(x_init, ps, st)
     for x in x_rest
         (h, c), st = l.lstm_cell((x, h, c), ps, st)

--- a/docs/src/devdocs/layer_implementation.md
+++ b/docs/src/devdocs/layer_implementation.md
@@ -53,7 +53,7 @@ An example implementation would be
 ```julia
 function (l::LSTM)(x::AbstractArray{T,3}, ps::NamedTuple, st::NamedTuple) where {T}
     (h, c), st = s.lstm_cell(view(x, :, 1, :), ps, st)
-    for i in 1:size(x, 2)
+    for i in 2:size(x, 2)
         (h, c), st = s.lstm_cell((view(x, :, i, :), h, c), ps, st)
     end
     return h, st

--- a/docs/src/devdocs/layer_implementation.md
+++ b/docs/src/devdocs/layer_implementation.md
@@ -51,6 +51,10 @@ varying how calls are made at different timesteps.
 An example implementation would be
 
 ```julia
+struct LSTM{L} <: Lux.AbstractExplicitContainerLayer{(:lstm_cell,)}
+    lstm_cell::L
+end
+
 function (l::LSTM)(x::AbstractArray{T,3}, ps::NamedTuple, st::NamedTuple) where {T}
     x_init, x_rest = Iterators.peel(eachslice(x, dims = 2))
     (h, c), st = l.lstm_cell(x_init, ps, st)

--- a/examples/SimpleRNN/main.jl
+++ b/examples/SimpleRNN/main.jl
@@ -65,7 +65,7 @@ function (s::SpiralClassifier)(x::AbstractArray{T, 3}, ps::NamedTuple,
     ## We use `view(x, :, 1, :)` to get the first element in the sequence without copying it
     (h, c), st_lstm = s.lstm_cell(view(x, :, 1, :), ps.lstm_cell, st.lstm_cell)
     ## Now that we have the hidden state we will pass the input and hidden state jointly
-    for i in 1:size(x, 2)
+    for i in 2:size(x, 2)
         (h, c), st_lstm = s.lstm_cell((view(x, :, i, :), h, c), ps.lstm_cell, st_lstm)
     end
     ## After running through the sequence we will pass the output through the classifier

--- a/examples/SimpleRNN/main.jl
+++ b/examples/SimpleRNN/main.jl
@@ -64,7 +64,7 @@ function (s::SpiralClassifier)(x::AbstractArray{T, 3}, ps::NamedTuple,
     ## See that the parameters and states are automatically populated into a field called `lstm_cell`
     ## We use `eachslice` to get the elements in the sequence without copying,
     ## and `Iterators.peel` to split out the first element for LSTM initialization.
-    x_init, x_rest = Iterators.peel(eachslice(x, dims = 2))
+    x_init, x_rest = Iterators.peel(eachslice(x; dims=2))
     (h, c), st_lstm = s.lstm_cell(x_init, ps.lstm_cell, st.lstm_cell)
     ## Now that we have the hidden state we will pass the input and hidden state jointly
     for x in x_rest


### PR DESCRIPTION
Perhaps something like this would be more robust, though not sure if you'd prefer that for documentation:

```julia
x_init, x_rest = Iterators.peel(eachslice(x, dims=2))
```
