### PR TITLE
Make normalization more AD friendly (Diffractor)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lux"
 uuid = "b2108857-7c20-44ae-9111-449ecde12c47"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.4.20"
+version = "0.4.21"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -189,3 +189,6 @@ Split up `x` into `N` equally sized chunks (along dimension `1`).
 
 # Val utilities
 get_known(::Val{T}) where {T} = T
+
+# Copy and don't allow gradient propagation
+_copy_autodiff_barrier(x) = copy(x)


### PR DESCRIPTION
Diffractor use relies on https://github.com/JuliaDiff/Diffractor.jl/pull/89

## Some Benchmarks:

Tested on julia master

### ResNet18

```julia
using Diffractor, Zygote, Boltz, Lux

model, ps, st = resnet(:resnet18);
ps, st = (ps, st) .|> gpu;

x = randn(Float32, 224, 224, 3, 1) |> gpu;

model(x, ps, st);

loss_function(model, x, ps, st) = sum(model(x, ps, st)[1])
l(x, p) = loss_function(model, x, p, st)

l(x, ps)

@time Diffractor.gradient(l, x, ps);  # 26.025503 seconds (31.82 M allocations: 2.033 GiB, 3.84% gc time, 92.70% compilation time)
@time Zygote.gradient(l, x, ps);  # 123.329143 seconds (59.74 M allocations: 3.654 GiB, 1.52% gc time, 92.13% compilation time)
```

### ResNet50

```julia
using Diffractor, Zygote, Boltz, Lux

model, ps, st = resnet(:resnet50);
ps, st = (ps, st) .|> gpu;

x = randn(Float32, 224, 224, 3, 1) |> gpu;

model(x, ps, st);

loss_function(model, x, ps, st) = sum(model(x, ps, st)[1])
l(x, p) = loss_function(model, x, p, st)

l(x, ps)

@time Diffractor.gradient(l, x, ps);  # 39.250322 seconds (34.66 M allocations: 2.212 GiB, 2.55% gc time, 95.59% compilation time)
@time Zygote.gradient(l, x, ps);  # 352.995727 seconds (71.11 M allocations: 4.367 GiB, 0.70% gc time, 99.72% compilation time)
```