### PR TITLE
Introducing LuxLib.jl: Effectively pullout some of the custom layer implementations from Lux.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         group:
-          - Lux    # Core Framework
-          - Boltz  # Prebuilt Models using Lux
+          - Lux     # Core Framework
+          - Boltz   # Prebuilt Models using Lux
+          - LuxLib  # Backend of Lux
         version:
           - '1.6'      # JET tests are disabled on 1.6
           - '1.7'

--- a/.github/workflows/CINightly.yml
+++ b/.github/workflows/CINightly.yml
@@ -20,6 +20,7 @@ jobs:
         group:
           - Lux    # Core Framework
           - Boltz  # Prebuilt Models using Lux
+          - LuxLib  # Backend of Lux
         version:
           - 'nightly'  # merge even if tests fail
     steps:

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Run CompatHelper"
         run: |
           import CompatHelper
-          CompatHelper.main(; subdirs=["", "examples", "lib/Boltz"])
+          CompatHelper.main(; subdirs=["", "examples", "lib/Boltz", "lib/LuxLib"])
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - name: Install documentation dependencies
-        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(), "lib/LuxLib"))); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Install examples dependencies
         run: julia --project=examples -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Lux 🔥
 
+[![Join the chat at https://julialang.zulipchat.com #machine-learning](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/machine-learning)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Latest Docs](https://img.shields.io/badge/docs-latest-blue.svg)](http://lux.csail.mit.edu/dev/)
 [![Stable Docs](https://img.shields.io/badge/docs-stable-blue.svg)](http://lux.csail.mit.edu/stable/)
+
 [![CI](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml)
 [![CI Nightly](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml)
 [![codecov](https://codecov.io/gh/avik-pal/Lux.jl/branch/main/graph/badge.svg?token=IMqBM1e3hz)](https://codecov.io/gh/avik-pal/Lux.jl)
+[![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/Lux)](https://pkgs.genieframework.com?packages=Lux)
+
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
-[![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/Lux)](https://pkgs.genieframework.com?packages=Lux)
 
 The 🔥 Deep Learning Framework
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,6 +3,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
+LuxLib = "82251201-b29d-42c6-8e01-566dec8acb11"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,10 +1,10 @@
-using Documenter, DocumenterMarkdown, Lux, Pkg
+using Documenter, DocumenterMarkdown, Lux, LuxLib, Pkg
 
 deployconfig = Documenter.auto_detect_deploy_system()
 Documenter.post_status(deployconfig; type="pending", repo="github.com/avik-pal/Lux.jl.git")
 
 makedocs(; sitename="Lux", authors="Avik Pal et al.", clean=true, doctest=true,
-         modules=[Lux], strict=[
+         modules=[Lux, LuxLib], strict=[
              :doctest,
              :linkcheck,
              :parse_error,

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -112,9 +112,12 @@ nav:
       - "Utilities": "api/utilities.md"
       - "Experimental": "api/contrib.md"
   - "Frameworks":
-      - "Boltz.jl": "lib/Boltz/index.md"
-      - "FluxMPI.jl": "https://avik-pal.github.io/FluxMPI.jl/dev/"
-      - "NNlib.jl": "https://fluxml.ai/Flux.jl/stable/models/nnlib/"
+      - "Boltz": "lib/Boltz/index.md"
+      - "FluxMPI": "https://avik-pal.github.io/FluxMPI.jl/dev/"
+      - "NNlib": "https://fluxml.ai/Flux.jl/stable/models/nnlib/"
+      - "LuxLib":
+        - "Introduction": "lib/LuxLib/index.md"
+        - "API Reference": "lib/LuxLib/api.md"
   - "Development Documentation":
       - "Style Guide": "devdocs/style_guide.md"
       - "Layer Implementation": "devdocs/layer_implementation.md"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,18 @@
 # Introduction
 
+[![Join the chat at https://julialang.zulipchat.com #machine-learning](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/machine-learning)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Latest Docs](https://img.shields.io/badge/docs-latest-blue.svg)](http://lux.csail.mit.edu/dev/)
+[![Stable Docs](https://img.shields.io/badge/docs-stable-blue.svg)](http://lux.csail.mit.edu/stable/)
+
+[![CI](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml)
+[![CI Nightly](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml)
+[![codecov](https://codecov.io/gh/avik-pal/Lux.jl/branch/main/graph/badge.svg?token=IMqBM1e3hz)](https://codecov.io/gh/avik-pal/Lux.jl)
+[![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/Lux)](https://pkgs.genieframework.com?packages=Lux)
+
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+[![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
+
 Welcome to the documentation of Lux!
 
 # What is Lux?

--- a/docs/src/lib/Boltz/index.md
+++ b/docs/src/lib/Boltz/index.md
@@ -1,5 +1,18 @@
 # Boltz ⚡
 
+[![Join the chat at https://julialang.zulipchat.com #machine-learning](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/machine-learning)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Latest Docs](https://img.shields.io/badge/docs-latest-blue.svg)](http://lux.csail.mit.edu/dev/lib/Boltz)
+[![Stable Docs](https://img.shields.io/badge/docs-stable-blue.svg)](http://lux.csail.mit.edu/stable/lib/Boltz)
+
+[![CI](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml)
+[![CI Nightly](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml)
+[![codecov](https://codecov.io/gh/avik-pal/Lux.jl/branch/main/graph/badge.svg?token=IMqBM1e3hz)](https://codecov.io/gh/avik-pal/Lux.jl)
+[![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/Boltz)](https://pkgs.genieframework.com?packages=Boltz)
+
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+[![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
+
 Accelerate ⚡ your ML research using pre-built Deep Learning Models with Lux.
 
 ## Installation

--- a/docs/src/lib/LuxLib/api.md
+++ b/docs/src/lib/LuxLib/api.md
@@ -1,0 +1,23 @@
+```@meta
+CurrentModule = LuxLib
+```
+
+## Dropout
+
+```@docs
+dropout
+```
+
+## Normalization
+
+```@docs
+batchnorm
+groupnorm
+layernorm
+```
+
+## Index
+
+```@index
+Pages = ["api.md"]
+```

--- a/docs/src/lib/LuxLib/index.md
+++ b/docs/src/lib/LuxLib/index.md
@@ -1,0 +1,29 @@
+# LuxLib
+
+[![Join the chat at https://julialang.zulipchat.com #machine-learning](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/machine-learning)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Latest Docs](https://img.shields.io/badge/docs-latest-blue.svg)](http://lux.csail.mit.edu/dev/lib/LuxLib/)
+[![Stable Docs](https://img.shields.io/badge/docs-stable-blue.svg)](http://lux.csail.mit.edu/stable/lib/LuxLib/)
+
+[![CI](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml)
+[![CI Nightly](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml)
+[![codecov](https://codecov.io/gh/avik-pal/Lux.jl/branch/main/graph/badge.svg?token=IMqBM1e3hz)](https://codecov.io/gh/avik-pal/Lux.jl)
+[![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/LuxLib)](https://pkgs.genieframework.com?packages=LuxLib)
+
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+[![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
+
+
+Backend for [Lux.jl](http://lux.csail.mit.edu/stable).
+
+## Tutorials
+
+This is a developer-facing project and most users **should not** depend on it directly. As
+such, we don't have tutorials for this package. Instead, we recommend you check out the
+[Lux tutorials](http://lux.csail.mit.edu/stable/examples/examples/).
+
+## What's the distinction from NNlib.jl?
+
+Think of this package as a temporary location for functionalities that will move into
+NNlib.jl. At the moment, this is supposed to be a heavier dependency than NNlib.jl, and
+it makes no attempt to separate code across different architectures.

--- a/lib/Boltz/README.md
+++ b/lib/Boltz/README.md
@@ -1,5 +1,18 @@
 # Boltz ⚡
 
+[![Join the chat at https://julialang.zulipchat.com #machine-learning](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/machine-learning)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Latest Docs](https://img.shields.io/badge/docs-latest-blue.svg)](http://lux.csail.mit.edu/dev/lib/Boltz)
+[![Stable Docs](https://img.shields.io/badge/docs-stable-blue.svg)](http://lux.csail.mit.edu/stable/lib/Boltz)
+
+[![CI](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml)
+[![CI Nightly](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml)
+[![codecov](https://codecov.io/gh/avik-pal/Lux.jl/branch/main/graph/badge.svg?token=IMqBM1e3hz)](https://codecov.io/gh/avik-pal/Lux.jl)
+[![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/Boltz)](https://pkgs.genieframework.com?packages=Boltz)
+
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+[![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
+
 Accelerate ⚡ your ML research using pre-built Deep Learning Models with Lux
 
 ## Installation

--- a/lib/LuxLib/Project.toml
+++ b/lib/LuxLib/Project.toml
@@ -1,0 +1,24 @@
+name = "LuxLib"
+uuid = "82251201-b29d-42c6-8e01-566dec8acb11"
+authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
+version = "0.1.0"
+
+[deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CUDAKernels = "72cfdca4-0801-4ab0-bf6a-d52aa10adc57"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+NNlibCUDA = "a00861dc-f156-4864-bf3c-e6376f28a68d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[compat]
+CUDA = "3"
+CUDAKernels = "0.3, 0.4"
+ChainRulesCore = "1"
+KernelAbstractions = "0.7, 0.8"
+NNlib = "0.8"
+NNlibCUDA = "0.2"
+julia = "1.6"

--- a/lib/LuxLib/README.md
+++ b/lib/LuxLib/README.md
@@ -1,0 +1,29 @@
+# LuxLib
+
+[![Join the chat at https://julialang.zulipchat.com #machine-learning](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/machine-learning)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Latest Docs](https://img.shields.io/badge/docs-latest-blue.svg)](http://lux.csail.mit.edu/dev/lib/LuxLib/)
+[![Stable Docs](https://img.shields.io/badge/docs-stable-blue.svg)](http://lux.csail.mit.edu/stable/lib/LuxLib/)
+
+[![CI](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CI.yml)
+[![CI Nightly](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml/badge.svg)](https://github.com/avik-pal/Lux.jl/actions/workflows/CINightly.yml)
+[![codecov](https://codecov.io/gh/avik-pal/Lux.jl/branch/main/graph/badge.svg?token=IMqBM1e3hz)](https://codecov.io/gh/avik-pal/Lux.jl)
+[![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/LuxLib)](https://pkgs.genieframework.com?packages=LuxLib)
+
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+[![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
+
+
+Backend for [Lux.jl](http://lux.csail.mit.edu/stable).
+
+## Tutorials
+
+This is a developer-facing project and most users **should not** depend on it directly. As
+such, we don't have tutorials for this package. Instead, we recommend you check out the
+[Lux tutorials](http://lux.csail.mit.edu/stable/examples/examples/).
+
+## What's the distinction from NNlib.jl?
+
+Think of this package as a temporary location for functionalities that will move into
+NNlib.jl. At the moment, this is supposed to be a heavier dependency than NNlib.jl, and
+it makes no attempt to separate code across different architectures.

--- a/lib/LuxLib/src/LuxLib.jl
+++ b/lib/LuxLib/src/LuxLib.jl
@@ -1,0 +1,22 @@
+module LuxLib
+
+using ChainRulesCore, CUDA, CUDAKernels, KernelAbstractions, Markdown, NNlib, NNlibCUDA,
+      Random, Statistics
+import ChainRulesCore as CRC
+
+include("utils.jl")
+
+# Low-Level Implementations
+include("impl/groupnorm.jl")
+include("impl/normalization.jl")
+
+# User Facing
+include("api/batchnorm.jl")
+include("api/dropout.jl")
+include("api/groupnorm.jl")
+include("api/layernorm.jl")
+
+export batchnorm, groupnorm, layernorm
+export dropout
+
+end

--- a/lib/LuxLib/src/api/batchnorm.jl
+++ b/lib/LuxLib/src/api/batchnorm.jl
@@ -1,0 +1,101 @@
+@doc doc"""
+    batchnorm(x, scale, bias, running_mean, running_var; momentum, epsilon, training)
+
+Batch Normalization. For details see [1].
+
+Batch Normalization computes the mean and variance for each
+``D_1 \times ... \times D_{N - 2} \times 1 \times D_N` input slice and normalises the input
+accordingly.
+
+## Arguments
+
+  - `x`: Input to be Normalized
+  - `scale`: Scale factor (``\gamma``) (can be `nothing`)
+  - `bias`: Bias factor (``\beta``) (can be `nothing`)
+  - `running_mean`: Running mean (can be `nothing`)
+  - `running_var`: Running variance (can be `nothing`)
+
+## Keyword Arguments
+
+  - `momentum`: Momentum for updating running mean and variance
+  - `epsilon`: Value added to the denominator for numerical stability
+  - `training`: Set to `Val(true)` if running in training mode
+
+## Returns
+
+Normalized Array of same size as `x`.
+
+## Performance Considerations
+
+If the input array is `2D`, `4D`, or `5D` `CuArray` with element types `Float16`, `Float32`
+and `Float64`, then the CUDNN code path will be used. In all other cases, a broadcasting
+fallback is used which is not highly optimized.
+
+## References
+
+[1] Ioffe, Sergey, and Christian Szegedy. "Batch normalization: Accelerating deep network
+    training by reducing internal covariate shift." International conference on machine
+    learning. PMLR, 2015.
+"""
+function batchnorm(x::AbstractArray{<:Real, N},
+                   scale::Union{AbstractVector{<:Real}, Nothing},
+                   bias::Union{AbstractVector{<:Real}, Nothing},
+                   running_mean::Union{AbstractVector{<:Real}, Nothing},
+                   running_var::Union{AbstractVector{<:Real}, Nothing}; momentum::Real,
+                   training::Val, epsilon::Real) where {N}
+    x_, xm, xv = _normalization(x, running_mean, running_var, scale, bias,
+                                collect([1:(N - 2); N]), training, momentum, epsilon)
+
+    return x_, (; running_mean=xm, running_var=xv)
+end
+
+_CUDNN_BATCHNORM_FLOAT = Union{Float32, Float64}
+
+_CUDNN_BATCHNORM_ARRAY_TYPE = Union{CuArray{<:_CUDNN_BATCHNORM_FLOAT, 2},
+                                    CuArray{<:_CUDNN_BATCHNORM_FLOAT, 4},
+                                    CuArray{<:_CUDNN_BATCHNORM_FLOAT, 5}}
+
+function batchnorm(x::_CUDNN_BATCHNORM_ARRAY_TYPE,
+                   scale::Union{CuVector{<:_CUDNN_BATCHNORM_FLOAT}, Nothing},
+                   bias::Union{CuVector{<:_CUDNN_BATCHNORM_FLOAT}, Nothing},
+                   running_mean::Union{CuVector{<:_CUDNN_BATCHNORM_FLOAT}, Nothing},
+                   running_var::Union{CuVector{<:_CUDNN_BATCHNORM_FLOAT}, Nothing};
+                   momentum::Real, training::Val, epsilon::Real)
+    rm, rv = _get_batchnorm_statistics(x, running_mean, running_var, training)
+
+    x_ = _batchnorm_cudnn!(rm, rv, scale, bias, x, momentum, epsilon, training)
+    return x_, (; running_mean=rm, running_var=rv)
+end
+
+function _get_batchnorm_statistics(x, running_mean, running_var,
+                                   ::Val{training}) where {training}
+    if training
+        # NNlibCUDA silently updates running_mean and running_var. Copying them!
+        rm = _copy_autodiff_barrier(running_mean)
+        rv = _copy_autodiff_barrier(running_var)
+    else
+        N = ndims(x)
+        dims = collect([1:(N - 2); N])
+        rm = running_mean === nothing ? mean(x; dims) : running_mean
+        rv = running_var === nothing ? var(x; mean=rm, dims, corrected=false) : running_var
+    end
+    return rm, rv
+end
+
+function _batchnorm_cudnn!(running_mean, running_var, scale, bias, x, momentum, eps,
+                           ::Val{training}) where {training}
+    return NNlibCUDA.batchnorm(scale, bias, x, running_mean, running_var, momentum; eps,
+                               training)
+end
+
+function CRC.rrule(::typeof(_batchnorm_cudnn!), running_mean, running_var, scale, bias, x,
+                   momentum, epsilon, t::Val{training}) where {training}
+    y = _batchnorm_cudnn!(running_mean, running_var, scale, bias, x, momentum, epsilon, t)
+    function _batchnorm_cudnn!_pullback(dy)
+        dg, db, dx = NNlibCUDA.∇batchnorm(scale, bias, x, unthunk(dy), running_mean,
+                                          running_var, momentum; eps=epsilon, training)
+        return (NoTangent(), NoTangent(), NoTangent(), dg, db, dx, NoTangent(), NoTangent(),
+                NoTangent())
+    end
+    return y, _batchnorm_cudnn!_pullback
+end

--- a/lib/LuxLib/src/api/dropout.jl
+++ b/lib/LuxLib/src/api/dropout.jl
@@ -1,0 +1,77 @@
+"""
+    dropout(rng::AbstractRNG, x, p, ::Val{training}; dims, invp)
+    dropout(rng::AbstractRNG, x, mask, p, ::Val{training}, ::Val{update_mask} invp; dims)
+
+Dropout: Simple Way to prevent Neural Networks for Overfitting. For details see [1].
+
+## Arguments
+
+  - `rng`: Random number generator
+  - `x`: Input Array
+  - `mask`: Dropout Mask. If not used then it is constructed automatically
+  - `p`: Probability of an element to be dropped out
+  - `Val(training)`: If `true` then dropout is applied on `x` with probability `p` along
+    `dims`. Else, `x` is returned
+  - `Val(update_mask)`: If `true` then the mask is generated and used. Else, the `mask`
+    provided is directly used
+
+## Keyword Arguments
+
+  - `dims`: Dimensions along which dropout is applied
+  - `invp`: Inverse of the probability (``\frac{1}{p}``)
+
+## Returns
+
+  - Output Array after applying dropout
+  - Dropout Mask (if `training == false`, the returned value is meaningless)
+  - Updated state for the random number generator
+
+## References
+
+[1] Srivastava, Nitish, et al. "Dropout: a simple way to prevent neural networks from
+overfitting." The journal of machine learning research 15.1 (2014): 1929-1958.
+"""
+function dropout(rng::AbstractRNG, x::AbstractArray, p::T, ::Val{true}; dims,
+                 invp::T=inv(p)) where {T}
+    rng = _replicate(rng)
+    mask = _generate_dropout_mask(rng, x, p, invp; dims)
+    return (x .* ignore_derivatives(mask), mask, rng)
+end
+
+function dropout(rng::AbstractRNG, x::AbstractArray, p::T, ::Val{false}; dims,
+                 invp::T=inv(p)) where {T}
+    return (x, x, rng)
+end
+
+function dropout(rng::AbstractRNG, x::AbstractArray, mask::AbstractArray, p::T, t::Val,
+                 ::Val{true}; dims, invp::T=inv(p)) where {T}
+    return dropout(rng, x, p, t; dims, invp)
+end
+
+function dropout(rng::AbstractRNG, x::AbstractArray{T1, N}, mask::AbstractArray{T2, N},
+                 p::T, ::Val{true}, ::Val{false}; dims, invp::T=inv(p)) where {T, T1, T2, N}
+    if size(x) != size(mask)
+        return dropout(rng, x, p, Val(true); dims, invp)
+    end
+    return x .* ignore_derivatives(mask), mask, rng
+end
+
+function dropout(rng::AbstractRNG, x::AbstractArray{T1, N}, mask::AbstractArray{T2, N},
+                 p::T, ::Val{false}, ::Val{false}; dims,
+                 invp::T=inv(p)) where {T, T1, T2, N}
+    return (x, mask, rng)
+end
+
+@inline _dropout_shape(s, ::Colon) = size(s)
+@inline function _dropout_shape(s, dims)
+    return tuple((i in dims ? si : 1 for (i, si) in enumerate(size(s)))...)
+end
+
+@inline _dropout_kernel(y, p, invp) = y > p ? invp : oftype(y, 0)
+
+@inline function _generate_dropout_mask(rng::AbstractRNG, x, p, invp; dims)
+    realfptype = float(real(eltype(x)))
+    y = rand!(rng, similar(x, realfptype, _dropout_shape(x, dims)))
+    y .= _dropout_kernel.(y, p, invp)
+    return y
+end

--- a/lib/LuxLib/src/api/groupnorm.jl
+++ b/lib/LuxLib/src/api/groupnorm.jl
@@ -1,0 +1,138 @@
+@doc doc"""
+    groupnorm(x, scale, bias; groups, epsilon)
+    groupnorm(x, scale, bias, running_mean, running_var; groups, momentum, training,
+              epsilon)
+
+Group Normalization. For details see [1].
+
+This op is similar to batch normalization, but statistics are shared across equally-sized
+groups of channels and not shared across batch dimension. Thus, group normalization does not
+depend on the batch composition and does not require maintaining internal state for storing
+statistics.
+
+## Arguments
+
+  - `x`: Input to be Normalized
+  - `scale`: Scale factor (``\gamma``) (can be `nothing`)
+  - `bias`: Bias factor (``\beta``) (can be `nothing`)
+  - `running_mean`: Running mean of the inputs. Must be an `AbstractVector` or `nothing`.
+  - `running_var`: Running variance of the inputs. Must be an `AbstractVector` or `nothing`.
+
+## Keyword Arguments
+
+  - `groups`: Number of groups
+  - `momentum`: Momentum for updating running mean and variance.
+  - `training`: Set to `Val(true)` if running in training mode.
+  - `epsilon`: Value added to the denominator for numerical stability
+
+## Returns
+
+If using the first function signature, then the only the normalized array is returned.
+
+Otherwise, the normalized array and a named tuple containing updated running mean and
+updated running variance are returned.
+
+## Additional Notes
+
+`running_mean`, `running_var`, `momentum`, and `training` exist only for backwards
+compatibility reasons. There is no well documented evidence in literature that tracking
+statistics for group normalization actually helps. It is recommended to not use these
+arguments at all.
+
+## Performance Considerations
+
+The most common case of this Op -- `x` is a 4D array and there is no statistics tracking --
+is optimized using KernelAbstractions and has a fast custom backwards pass implemented. All
+other cases have a fallback implementation which is not especially optimized.
+
+Additionally, if the element types of `x`, `scale`, and `bias` are not same and not one of
+`Float32` and `Float64`, then the Op uses the slower fallback implementation. We have tested
+the code path for `Float16` and it works, but gradient accumulation is extremely fragile.
+Hence, for `Float16` inputs, it uses the fallback implementation.
+
+If the batch size is small (< 16), then the fallback implementation will be faster than the
+KA version. However, this customization is not possible using the direct `groupnorm`
+interface.
+
+## References
+
+[1] Wu, Yuxin, and Kaiming He. "Group normalization." Proceedings of the European conference
+    on computer vision (ECCV). 2018.
+"""
+function groupnorm(x::AbstractArray{T, 4}, scale::AbstractVector{T},
+                   bias::AbstractVector{T}; groups::Int,
+                   epsilon::Real) where {T <: _GROUPNORM_IMPL_FLOAT}
+    _assert_same_device(x, scale, bias)
+    if length(scale) != length(bias) != size(x, 3)
+        throw(ArgumentError("Length of `scale` and `bias` must be equal to the number of " *
+                            "channels (N - 1 dim of the input array)."))
+    end
+    if size(x, 3) % groups != 0
+        throw(ArgumentError("Number of channels $(size(x, 3)) must be divisible by the " *
+                            "number of groups $groups."))
+    end
+
+    return first(_groupnorm(x, groups, scale, bias, T(epsilon)))
+end
+
+function groupnorm(x::AbstractArray{T, 4}, scale::AbstractVector{T},
+                   bias::AbstractVector{T}, ::Nothing, ::Nothing; groups::Int,
+                   epsilon::Real, momentum=0.9f0,
+                   training::Val=Val(true)) where {T <: _GROUPNORM_IMPL_FLOAT}
+    return groupnorm(x, scale, bias; groups, epsilon),
+           (running_mean=nothing, running_var=nothing)
+end
+
+# For any reason if the fast path is not possible, then we use the fallback implementation
+function groupnorm(x::AbstractArray, scale::AbstractVector, bias::AbstractVector;
+                   groups::Int, epsilon::Real)
+    return groupnorm(x, scale, bias, nothing, nothing; groups, epsilon,
+                     momentum=eltype(x)(0.9), training=Val(true))[1]
+end
+
+# Slow Fallback (without custom Pullback Implementation)
+function groupnorm(x::AbstractArray{<:Real, N},
+                   scale::Union{Nothing, AbstractVector{<:Real}},
+                   bias::Union{Nothing, AbstractVector{<:Real}},
+                   running_mean::Union{Nothing, AbstractVector{<:Real}},
+                   running_var::Union{Nothing, AbstractVector{<:Real}}; groups::Int,
+                   momentum::Real, training::Val, epsilon::Real) where {N}
+    _assert_same_device(x, scale, bias, running_mean, running_var)
+    if scale !== nothing && bias !== nothing && length(scale) != length(bias) != size(x, 3)
+        throw(ArgumentError("Length of `scale` and `bias` must be equal to the number of " *
+                            "channels (N - 1 dim of the input array)."))
+    end
+    if size(x, 3) % groups != 0
+        throw(ArgumentError("Number of channels $(size(x, 3)) must be divisible by the " *
+                            "number of groups $groups."))
+    end
+
+    sz = size(x)
+    x_reshaped = reshape(x, sz[1:(N - 2)]..., sz[N - 1] ÷ groups, groups, sz[N])
+    x_, xmean, xvar = _normalization(x_reshaped, running_mean, running_var, scale, bias,
+                                     collect(1:(N - 1)), training, momentum, epsilon)
+
+    return reshape(x_, sz), (; running_mean=xmean, running_var=xvar)
+end
+
+# Custom Pullbacks
+function CRC.rrule(::typeof(groupnorm), x::AbstractArray{T, 4}, scale::AbstractVector{T},
+                   bias::AbstractVector{T}; groups::Int,
+                   epsilon::Real) where {T <: _GROUPNORM_IMPL_FLOAT}
+    _assert_same_device(x, scale, bias)
+    if length(scale) != length(bias) != size(x, 3)
+        throw(ArgumentError("Length of `scale` and `bias` must be equal to the number of " *
+                            "channels (N - 1 dim of the input array)."))
+    end
+    if size(x, 3) % groups != 0
+        throw(ArgumentError("Number of channels $(size(x, 3)) must be divisible by the " *
+                            "number of groups $groups."))
+    end
+
+    y, mu, rsig = _groupnorm(x, groups, scale, bias, epsilon)
+    function groupnorm_pullback(dy)
+        dx, dscale, dbias = _dgroupnorm(dy, y, x, groups, scale, bias, mu, rsig)
+        return NoTangent(), dx, dscale, dbias
+    end
+    return y, groupnorm_pullback
+end

--- a/lib/LuxLib/src/api/layernorm.jl
+++ b/lib/LuxLib/src/api/layernorm.jl
@@ -1,0 +1,45 @@
+@doc doc"""
+    layernorm(x, scale, bias; dims, epsilon)
+
+Layer Normalization. For details see [1].
+
+Given an input array ``x``, this layer computes
+
+```math
+y = \frac{x - \mathbb{E}[x]}{\sqrt{Var[x] + \epsilon}} * \gamma + \beta
+```
+
+## Arguments
+
+  - `x`: Input to be Normalized
+  - `scale`: Scale factor (``\gamma``) (can be `nothing`)
+  - `bias`: Bias factor (``\beta``) (can be `nothing`)
+
+## Keyword Arguments
+
+  - `dims`: Dimensions along which the mean and std of `x` is computed
+  - `epsilon`: Value added to the denominator for numerical stability
+
+## Returns
+
+Normalized Array of same size as `x`.
+
+## References
+
+[1] Ba, Jimmy Lei, Jamie Ryan Kiros, and Geoffrey E. Hinton. "Layer normalization." arXiv
+    preprint arXiv:1607.06450 (2016).
+"""
+function layernorm(x::AbstractArray{<:Real, N}, scale::AbstractArray{<:Real, N},
+                   bias::AbstractArray{<:Real, N}; dims, epsilon) where {N}
+    _mean = mean(x; dims)
+    _rstd = 1 ./ (std(x; dims, mean=_mean, corrected=false) .+ epsilon)
+
+    return scale .* (x .- _mean) .* _rstd .+ bias
+end
+
+function layernorm(x::AbstractArray, ::Nothing, ::Nothing; dims, epsilon)
+    _mean = mean(x; dims)
+    _rstd = 1 ./ (std(x; dims, mean=_mean, corrected=false) .+ epsilon)
+
+    return (x .- _mean) .* _rstd
+end

--- a/lib/LuxLib/src/impl/groupnorm.jl
+++ b/lib/LuxLib/src/impl/groupnorm.jl
@@ -1,0 +1,120 @@
+# Launch Heuristics
+_linear_threads_groupnorm(::CPU) = Threads.nthreads()
+_linear_threads_groupnorm(::CUDADevice) = (16, 16)
+_linear_threads_groupnorm(::GPU) = 256
+
+_GROUPNORM_IMPL_FLOAT = Union{Float32, Float64}
+
+# Low-Level Kernels
+## Original Implementation: https://github.com/pytorch/pytorch/blob/master/caffe2/operators/group_norm_op.cu
+@kernel function _compute_fused_params_kernel!(scale, bias, @Const(C), @Const(K),
+                                               @Const(mu), @Const(rsig), @Const(gamma),
+                                               @Const(beta))
+    idx = @index(Global)
+    ng = _div_idx(idx, K)
+    c = _mod_idx(idx, C)
+
+    @inbounds scale_val = gamma[c] * rsig[ng]
+    @inbounds scale[idx] = scale_val
+    @inbounds bias[idx] = beta[c] - mu[ng] * scale_val
+end
+
+@kernel function _groupnorm_forward_kernel!(Y, @Const(WxH), @Const(X), @Const(scale),
+                                            @Const(bias))
+    idx = @index(Global)
+    nc = _div_idx(idx, WxH)
+    @inbounds Y[idx] = X[idx] * scale[nc] + bias[nc]
+end
+
+@kernel function _groupnorm_dy_dscale_kernel!(dY_dscale, @Const(C), @Const(K), @Const(rsig),
+                                              @Const(gamma))
+    idx = @index(Global)
+    ng = _div_idx(idx, K)
+    c = _mod_idx(idx, C)
+
+    @inbounds dY_dscale[idx] = gamma[c] * rsig[ng]
+end
+
+@kernel function _groupnorm_xscale_and_bias_kernel!(X_scale, bias, @Const(alpha),
+                                                    @Const(mu), @Const(rsig),
+                                                    @Const(ds_sum), @Const(db_sum))
+    idx = @index(Global)
+    @inbounds x = (db_sum[idx] * mu[idx] - ds_sum[idx]) * (rsig[idx]^3) * alpha
+    @inbounds X_scale[idx] = x
+    @inbounds bias[idx] = -(x * mu[idx] + db_sum[idx] * rsig[idx] * alpha)
+end
+
+@kernel function _groupnorm_dx_kernel!(dX, @Const(WxH), @Const(K), @Const(dY_dscale),
+                                       @Const(dY), @Const(X_scale), @Const(X), @Const(bias))
+    idx = @index(Global)
+    nc = _div_idx(idx, WxH)
+    ng = _div_idx(nc, K)
+    @inbounds dX[idx] = dY[idx] * dY_dscale[nc] + X_scale[ng] * X[idx] + bias[ng]
+end
+
+# High-Level Function (Not User Facing)
+@inbounds function _groupnorm(X::AbstractArray{T, 4}, G::Int, gamma::AbstractVector{T},
+                              beta::AbstractVector{T}, epsilon::T) where {T}
+    W, H, C, N = size(X)
+    K = div(C, G)
+
+    X_reshaped = reshape(X, (W, H, K, G, N))
+    Y = similar(X)
+    mu = mean(X_reshaped; dims=(1, 2, 3))
+    rsig = 1 ./ (std(X_reshaped; mean=mu, dims=(1, 2, 3), corrected=false) .+ epsilon)
+
+    _scale = similar(X, (C, N))
+    _bias = similar(X, (C, N))
+
+    device = get_device(X)
+
+    n = _linear_threads_groupnorm(device)
+    compute_fixed_params! = _compute_fused_params_kernel!(device, n, size(_scale))
+    groupnorm_forward! = _groupnorm_forward_kernel!(device, n, size(X))
+
+    wait(compute_fixed_params!(_scale, _bias, C, K, mu, rsig, gamma, beta;
+                               ndrange=size(_scale)))
+    wait(groupnorm_forward!(Y, W * H, X, _scale, _bias; ndrange=size(Y)))
+
+    return Y, mu, rsig
+end
+
+@inbounds function _dgroupnorm(dY::AbstractArray{T, 4}, Y::AbstractArray{T, 4},
+                               X::AbstractArray{T, 4}, G::Int, gamma::AbstractVector{T},
+                               beta::AbstractVector{T}, mu::AbstractArray{T, 5},
+                               rsig::AbstractArray{T, 5}) where {T}
+    W, H, C, N = size(X)
+    K = div(C, G)
+    WxH = W * H
+    device = get_device(X)
+    n = _linear_threads_groupnorm(device)
+
+    dbias = reshape(sum(dY; dims=(1, 2)), (1, 1, K, G, N))
+    dscale = reshape(sum(X .* dY; dims=(1, 2)), (1, 1, K, G, N))
+
+    dY_dscale = similar(X, (C, N))
+    groupnorm_dy_dscale! = _groupnorm_dy_dscale_kernel!(device, n, size(dY_dscale))
+    ev = groupnorm_dy_dscale!(dY_dscale, C, K, rsig, gamma; ndrange=size(dY_dscale))
+
+    gamma_ = reshape(gamma, (1, 1, K, G, 1))
+    db_sum = sum(gamma_ .* dbias; dims=3)
+    ds_sum = sum(gamma_ .* dscale; dims=3)
+    wait(ev)
+
+    X_scale = similar(X, (G, N))
+    bias = similar(X, (G, N))
+
+    groupnorm_xscale_and_bias! = _groupnorm_xscale_and_bias_kernel!(device, n,
+                                                                    size(X_scale))
+    wait(groupnorm_xscale_and_bias!(X_scale, bias, T(1 / (K * WxH)), mu, rsig, ds_sum,
+                                    db_sum; ndrange=size(X_scale)))
+
+    dX = similar(X)
+    groupnorm_dx! = _groupnorm_dx_kernel!(device, n, size(dX))
+    ev = groupnorm_dx!(dX, WxH, K, dY_dscale, dY, X_scale, X, bias; ndrange=size(dX))
+    dgamma = vec(sum((-dbias .* mu .+ dscale) .* rsig; dims=5))
+    dbeta = vec(sum(dbias; dims=5))
+    wait(ev)
+
+    return dX, dgamma, dbeta
+end

--- a/lib/LuxLib/src/impl/normalization.jl
+++ b/lib/LuxLib/src/impl/normalization.jl
@@ -1,0 +1,81 @@
+# Generic Normalization Implementation
+function _update_normalization_statistics(x::AbstractArray{<:Real, N},
+                                          running_mean::AbstractArray{<:Real, N},
+                                          running_var::AbstractArray{<:Real, N},
+                                          batchmean::AbstractArray{<:Real, N},
+                                          batchvar::AbstractArray{<:Real, N},
+                                          momentum::Real, reduce_dims) where {N}
+    sx = size(x)
+    m = (eltype(x))(prod(sx[reduce_dims]))
+    if last(reduce_dims) != N
+        batchmean = mean(batchmean; dims=N)
+        batchvar = mean(batchvar; dims=N)
+    end
+    running_mean = @. (1 - momentum) * running_mean + momentum * batchmean
+    running_var = @. (1 - momentum) * running_var + momentum * batchvar * (m / (m - one(m)))
+    return (running_mean, running_var)
+end
+
+@generated function _get_batch_statistics(x::AbstractArray, running_mean::R, running_var::R,
+                                          reduce_dims, ::Val{training}, momentum::Real,
+                                          epsilon::Real) where {R, training}
+    calls = []
+    if !training
+        if R == Nothing
+            push!(calls, :(batchmean = mean(x; dims=reduce_dims)))
+            push!(calls,
+                  :(batchvar = var(x; mean=batchmean, dims=reduce_dims, corrected=false)))
+        else
+            push!(calls, :((batchmean, batchvar) = (running_mean, running_var)))
+        end
+    else
+        push!(calls, :(batchmean = mean(x; dims=reduce_dims)))
+        push!(calls,
+              :(batchvar = var(x; mean=batchmean, dims=reduce_dims, corrected=false)))
+
+        if R != Nothing
+            push!(calls,
+                  :(_stats = _update_normalization_statistics(x, running_mean, running_var,
+                                                              batchmean, batchvar, momentum,
+                                                              reduce_dims)))
+            push!(calls, :((running_mean, running_var) = _stats))
+        end
+    end
+    push!(calls, :(return ((batchmean, batchvar), (running_mean, running_var))))
+    return Expr(:block, calls...)
+end
+
+@generated function _affine_normalize(x::AbstractArray, xmean::ST, xvar::ST, scale::A,
+                                      bias::A, epsilon::Real) where {ST, A}
+    if A != Nothing
+        return :(return scale .* (x .- xmean) ./ sqrt.(xvar .+ epsilon) .+ bias)
+    else
+        return :(return (x .- xmean) ./ sqrt.(xvar .+ epsilon))
+    end
+end
+
+function _normalization_impl(x::AbstractArray, running_mean::R, running_var::R, scale::A,
+                             bias::A, reduce_dims, training::Val, momentum::Real,
+                             epsilon::Real) where {R, A}
+    _stats = _get_batch_statistics(x, running_mean, running_var, reduce_dims, training,
+                                   momentum, epsilon)
+    _m = mean(x; dims=reduce_dims)
+    _v = var(x; dims=reduce_dims, corrected=false, mean=_m)
+    (batchmean, batchvar), (running_mean, running_var) = _stats
+    x_norm = _affine_normalize(x, batchmean, batchvar, scale, bias, epsilon)
+    return (x_norm, running_mean, running_var)
+end
+
+function _normalization(x::AbstractArray, running_mean::Union{AbstractVector, Nothing},
+                        running_var::Union{AbstractVector, Nothing},
+                        scale::Union{AbstractVector, Nothing},
+                        bias::Union{AbstractVector, Nothing}, reduce_dims, training::Val,
+                        momentum::Real, epsilon::Real)
+    rm_ = _reshape_into_proper_shape(running_mean, x)
+    rv_ = _reshape_into_proper_shape(running_var, x)
+    s_ = _reshape_into_proper_shape(scale, x)
+    b_ = _reshape_into_proper_shape(bias, x)
+    x_, rm, rv = _normalization_impl(x, rm_, rv_, s_, b_, reduce_dims, training, momentum,
+                                     epsilon)
+    return x_, _vec(rm), _vec(rv)
+end

--- a/lib/LuxLib/src/utils.jl
+++ b/lib/LuxLib/src/utils.jl
@@ -1,0 +1,61 @@
+_div_idx(idx, n) = div(idx - 1, n) + 1
+_mod_idx(idx, n) = mod(idx - 1, n) + 1
+
+@static if VERSION >= v"1.7"
+    get_device(x) = KernelAbstractions.get_device(x)
+else
+    # KA.get_device is not present in <= v0.7 but that is what works on julia 1.6
+    get_device(x::CuArray) = CUDADevice()
+    get_device(x::Array) = CPU()
+    function get_device(x)
+        throw(ArgumentError("get_device not implemented for $(typeof(x)). This is an" *
+                            "undesirable codepath. Please use julia 1.7+ for more " *
+                            "meaningful error messages using KA.jl."))
+    end
+end
+
+_get_device(::Nothing) = nothing
+_get_device(d) = hasmethod(get_device, (typeof(d),)) ? get_device(d) : nothing
+_get_device(t::Tuple) = filter(!isnothing, _get_device.(t))
+
+CRC.@non_differentiable _get_device(::Any)
+
+function _assert_same_device(args...)
+    devs = _get_device(args)
+    if !all(devs .== (first(devs),))
+        throw(ArgumentError("All arguments must be on the same device. This error is " *
+                            "encountered if you are calling a function with a mix of CPU " *
+                            "and GPU arrays."))
+    end
+    return
+end
+
+CRC.@non_differentiable _assert_same_device(::Any...)
+
+@inline @generated _vec(x::T) where {T} = hasmethod(vec, (T,)) ? :(vec(x)) : :x
+
+@inline @inbounds function _get_reshape_dims(sx::NTuple{N, <:Int}, ly::Int) where {N}
+    if ly == sx[N - 1]
+        return ntuple(i -> i == N - 1 ? ly : 1, N)
+    elseif N > 2 && ly == sx[N - 1] * sx[N - 2]
+        return ntuple(i -> i == (N - 1) || i == (N - 2) ? sx[i] : 1, N)
+    else
+        throw(ArgumentError("Invalid Dimensions!"))
+    end
+end
+
+CRC.@non_differentiable _get_reshape_dims(::Any...)
+
+@inline _reshape_into_proper_shape(::Nothing, y) = nothing
+@inline _reshape_into_proper_shape(x, y) = reshape(x, _get_reshape_dims(size(y), length(x)))
+
+# Copy and don't allow gradient propagation
+_copy_autodiff_barrier(x) = copy(x)
+_copy_autodiff_barrier(::Nothing) = nothing
+
+CRC.@non_differentiable _copy_autodiff_barrier(::Any)
+
+_replicate(rng::AbstractRNG) = copy(rng)
+_replicate(rng::CUDA.RNG) = deepcopy(rng)
+
+CRC.@non_differentiable _replicate(::Any)

--- a/lib/LuxLib/test/Project.toml
+++ b/lib/LuxLib/test/Project.toml
@@ -1,0 +1,17 @@
+[deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[compat]
+CUDA = "3"
+FiniteDifferences = "0.12"
+JET = "0.4, 0.5, 0.6"
+SafeTestsets = "0.0.1"
+Zygote = "0.6"
+julia = "1.6"

--- a/lib/LuxLib/test/api/batchnorm.jl
+++ b/lib/LuxLib/test/api/batchnorm.jl
@@ -1,0 +1,124 @@
+using CUDA, Random, Test
+using LuxLib
+
+include("../test_utils.jl")
+
+rng = MersenneTwister(0)
+
+function _setup_batchnorm(T, sz; affine::Bool=true, track_stats::Bool)
+    x = randn(T, sz)
+    scale = affine ? randn(T, sz[end - 1]) : nothing
+    bias = affine ? randn(T, sz[end - 1]) : nothing
+
+    if track_stats
+        running_mean = randn(T, sz[end - 1])
+        running_var = abs2.(randn(T, sz[end - 1]))
+        return x, scale, bias, running_mean, running_var
+    else
+        return x, scale, bias, nothing, nothing
+    end
+end
+
+@testset "Batch Normalization" begin
+    if cpu_testing()
+        for T in (Float16, Float32, Float64),
+            sz in ((4, 4, 6, 2), (8, 2), (4, 4, 4, 3, 2)),
+            training in (Val(true), Val(false)),
+            affine in (true, false),
+            track_stats in (true, false)
+
+            println("BN_CPU: $T $(sz) $training $affine $track_stats")
+
+            _f = (args...) -> batchnorm(args...; epsilon, training, momentum=T(0.9))
+
+            epsilon = T(1e-5)
+            x, scale, bias, rm, rv = _setup_batchnorm(T, sz; track_stats, affine)
+            @time y, nt = _f(x, scale, bias, rm, rv)
+
+            @inferred first(batchnorm(x, scale, bias, rm, rv; epsilon, training,
+                                      momentum=T(0.9)))
+            run_JET_tests(_f, x, scale, bias, rm, rv)
+            @test y isa Array{T, length(sz)}
+            @test size(y) == sz
+            if rm !== nothing
+                @test size(nt.running_mean) == (size(x, length(sz) - 1),)
+                @test size(nt.running_var) == (size(x, length(sz) - 1),)
+            end
+
+            Zygote.gradient(sum ∘ first ∘ _f, x, scale, bias, rm, rv)  # Compile
+            @time gs_x, gs_scale, gs_bias, _, _ = Zygote.gradient(sum ∘ first ∘ _f, x,
+                                                                  scale, bias, rm, rv)
+
+            if T != Float16
+                if affine
+                    __f = (args...) -> sum(first(batchnorm(x, args..., rm, rv; epsilon,
+                                                           training, momentum=T(0.9))))
+                    test_gradient_correctness_fdm(__f, scale, bias; atol=1.0f-2,
+                                                  rtol=1.0f-2)
+                else
+                    __f = (args...) -> sum(first(batchnorm(args..., scale, bias, rm, rv;
+                                                           epsilon, training,
+                                                           momentum=T(0.9))))
+                    test_gradient_correctness_fdm(__f, x; atol=1.0f-2, rtol=1.0f-2)
+                end
+            end
+        end
+    end
+
+    if gpu_testing()
+        for T in (Float32, Float64),
+            sz in ((4, 4, 6, 2), (8, 2), (4, 4, 4, 3, 2)),
+            training in (Val(true), Val(false)),
+            affine in (true, false),
+            track_stats in (true, false)
+
+            println("BN_GPU: $T $(sz) $training $affine $track_stats")
+
+            _f = (args...) -> batchnorm(args...; epsilon, training, momentum=T(0.9))
+
+            epsilon = T(1e-5)
+            x, scale, bias, rm, rv = _setup_batchnorm(T, sz; track_stats, affine)
+
+            x, scale, bias, rm, rv = (x, scale, bias, rm, rv) .|> cu
+            x = x .|> T
+            if scale !== nothing
+                scale = scale .|> T
+                bias = bias .|> T
+            end
+            if rm !== nothing
+                rm = rm .|> T
+                rv = rv .|> T
+            end
+
+            CUDA.@time y, nt = _f(x, scale, bias, rm, rv)
+
+            @inferred first(batchnorm(x, scale, bias, rm, rv; epsilon, training,
+                                      momentum=T(0.9)))
+            run_JET_tests(_f, x, scale, bias, rm, rv; call_broken=true)
+            @test y isa CuArray{T, length(sz)}
+            @test size(y) == sz
+            if rm !== nothing
+                @test size(nt.running_mean) == (size(x, length(sz) - 1),)
+                @test size(nt.running_var) == (size(x, length(sz) - 1),)
+            end
+
+            Zygote.gradient(sum ∘ first ∘ _f, x, scale, bias, rm, rv)  # Compile
+            CUDA.@time gs_x, gs_scale, gs_bias, _, _ = Zygote.gradient(sum ∘ first ∘ _f, x,
+                                                                       scale, bias, rm, rv)
+
+            # if T != Float16
+            #     if affine
+            #         __f = (args...) -> sum(first(batchnorm(args..., rm, rv; epsilon,
+            #                                                training, momentum=T(0.9))))
+            #         test_gradient_correctness_fdm(__f, x, scale, bias; atol=1.0f-2,
+            #                                       rtol=1.0f-2)
+            #     else
+            #         __f = (args...) -> sum(first(batchnorm(args..., scale, bias, rm, rv;
+            #                                                epsilon, training,
+            #                                                momentum=T(0.9))))
+            #         test_gradient_correctness_fdm(__f, x; atol=1.0f-2, rtol=1.0f-2)
+            #     end
+            # end
+        end
+    end
+end

--- a/lib/LuxLib/test/api/dropout.jl
+++ b/lib/LuxLib/test/api/dropout.jl
@@ -1,0 +1,196 @@
+using CUDA, Random, Statistics, Test
+using LuxLib
+
+include("../test_utils.jl")
+
+rng = MersenneTwister(0)
+
+@testset "Dropout" begin
+    if cpu_testing()
+        for T in (Float16, Float32, Float64),
+            x_shape in ((2, 3), (2, 2, 3), (2, 2, 3, 1), (2, 2, 1, 3, 1))
+
+            println("DRP_CPU: $T $(x_shape)")
+
+            x = randn(T, x_shape)
+
+            @inferred dropout(rng, x, T(0.5), Val(true); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, T(0.5), Val(true); dims=Colon())
+
+            @test y isa Array{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test mask_ isa Array{T, length(x_shape)}
+            @test size(mask_) == x_shape
+            @test rng != rng_
+
+            @inferred dropout(rng, x, T(0.5), Val(false); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, T(0.5), Val(false); dims=Colon())
+
+            @test y isa Array{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test rng == rng_
+            @test y == x
+        end
+    end
+
+    if gpu_testing()
+        for T in (Float16, Float32, Float64),
+            x_shape in ((2, 3), (2, 2, 3), (2, 2, 3, 1), (2, 2, 1, 3, 1))
+
+            println("DRP_GPU: $T $(x_shape)")
+
+            x = CUDA.randn(T, x_shape)
+
+            @inferred dropout(rng, x, T(0.5), Val(true); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, T(0.5), Val(true); dims=Colon())
+
+            @test y isa CuArray{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test mask_ isa CuArray{T, length(x_shape)}
+            @test size(mask_) == x_shape
+            @test rng != rng_
+
+            @inferred dropout(rng, x, T(0.5), Val(false); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, T(0.5), Val(false); dims=Colon())
+
+            @test y isa CuArray{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test rng == rng_
+            @test y == x
+        end
+    end
+end
+
+@testset "Dropout with Preset Mask" begin
+    if cpu_testing()
+        for T in (Float16, Float32, Float64),
+            x_shape in ((2, 3), (2, 2, 3), (2, 2, 3, 1), (2, 2, 1, 3, 1))
+
+            println("DRP_CPU: $T $(x_shape)")
+
+            x = randn(T, x_shape)
+            mask = rand(T, x_shape)
+
+            # Update mask
+            @inferred dropout(rng, x, mask, T(0.5), Val(true), Val(true); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, mask, T(0.5), Val(true), Val(true);
+                                     dims=Colon())
+
+            @test y isa Array{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test mask_ isa Array{T, length(x_shape)}
+            @test size(mask_) == x_shape
+            @test rng != rng_
+            @test mask != mask_
+
+            # Try using mask if possible (possible!!)
+            @inferred dropout(rng, x, mask, T(0.5), Val(true), Val(false); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, mask, T(0.5), Val(true), Val(false);
+                                     dims=Colon())
+
+            @test y isa Array{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test mask_ isa Array{T, length(x_shape)}
+            @test size(mask_) == x_shape
+            @test rng == rng_
+            @test mask == mask_
+
+            mask = rand(T, (x_shape[1:(end - 1)]..., 13))
+
+            # Try using mask if possible (not possible!!)
+            @inferred dropout(rng, x, mask, T(0.5), Val(true), Val(false); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, mask, T(0.5), Val(true), Val(false);
+                                     dims=Colon())
+
+            @test y isa Array{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test mask_ isa Array{T, length(x_shape)}
+            @test size(mask_) == x_shape
+            @test rng != rng_
+            @test mask != mask_
+
+            # Testing Mode
+            @inferred dropout(rng, x, mask, T(0.5), Val(false), Val(false); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, mask, T(0.5), Val(false), Val(false);
+                                     dims=Colon())
+
+            @test y isa Array{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test mask_ isa Array{T, length(x_shape)}
+            @test mask_ == mask
+            @test rng == rng_
+        end
+    end
+
+    if gpu_testing()
+        for T in (Float16, Float32, Float64),
+            x_shape in ((2, 3), (2, 2, 3), (2, 2, 3, 1), (2, 2, 1, 3, 1))
+
+            println("DRP_GPU: $T $(x_shape)")
+
+            x = CUDA.randn(T, x_shape)
+            mask = CUDA.rand(T, x_shape)
+
+            # Update mask
+            @inferred dropout(rng, x, mask, T(0.5), Val(true), Val(true); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, mask, T(0.5), Val(true), Val(true);
+                                     dims=Colon())
+
+            @test y isa CuArray{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test mask_ isa CuArray{T, length(x_shape)}
+            @test size(mask_) == x_shape
+            @test rng != rng_
+            @test mask != mask_
+
+            # Try using mask if possible (possible!!)
+            @inferred dropout(rng, x, mask, T(0.5), Val(true), Val(false); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, mask, T(0.5), Val(true), Val(false);
+                                     dims=Colon())
+
+            @test y isa CuArray{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test mask_ isa CuArray{T, length(x_shape)}
+            @test size(mask_) == x_shape
+            @test rng == rng_
+            @test mask == mask_
+
+            mask = CUDA.rand(T, (x_shape[1:(end - 1)]..., 13))
+
+            # Try using mask if possible (not possible!!)
+            @inferred dropout(rng, x, mask, T(0.5), Val(true), Val(false); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, mask, T(0.5), Val(true), Val(false);
+                                     dims=Colon())
+
+            @test y isa CuArray{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test mask_ isa CuArray{T, length(x_shape)}
+            @test size(mask_) == x_shape
+            @test rng != rng_
+            @test mask != mask_
+
+            # Testing Mode
+            @inferred dropout(rng, x, mask, T(0.5), Val(false), Val(false); dims=Colon())
+
+            y, mask_, rng_ = dropout(rng, x, mask, T(0.5), Val(false), Val(false);
+                                     dims=Colon())
+
+            @test y isa CuArray{T, length(x_shape)}
+            @test size(y) == x_shape
+            @test mask_ isa CuArray{T, length(x_shape)}
+            @test mask_ == mask
+            @test rng == rng_
+        end
+    end
+end

--- a/lib/LuxLib/test/api/groupnorm.jl
+++ b/lib/LuxLib/test/api/groupnorm.jl
@@ -1,0 +1,195 @@
+using CUDA, Test, Zygote
+using LuxLib
+
+include("../test_utils.jl")
+
+function _setup_groupnorm(T, sz, groups; track_stats::Bool)
+    x = randn(T, sz)
+    scale = randn(T, sz[end - 1])
+    bias = randn(T, sz[end - 1])
+
+    if track_stats
+        running_mean = randn(T, groups)
+        running_var = abs2.(randn(T, groups))
+        return x, scale, bias, running_mean, running_var
+    else
+        return x, scale, bias
+    end
+end
+
+function _groupnorm_generic_fallback(x, scale, bias, running_mean, running_var, training,
+                                     momentum, epsilon, groups)
+    sz = size(x)
+    N = ndims(x)
+    x_reshaped = reshape(x, sz[1:(N - 2)]..., sz[N - 1] ÷ groups, groups, sz[N])
+    x_, xmean, xvar = LuxLib._normalization(x_reshaped, running_mean, running_var, scale,
+                                            bias, collect(1:(N - 1)), training, momentum,
+                                            epsilon)
+
+    return reshape(x_, sz)
+end
+
+@testset "GroupNorm KernelAbstractions" begin
+    if cpu_testing()
+        for T in (Float32, Float64),
+            sz in ((16, 16, 6, 4), (32, 32, 6, 4), (64, 64, 12, 4)),
+            groups in (2, 3)
+
+            println("GN_CPU: $T $(sz) $groups")
+
+            _f = (args...) -> groupnorm(args...; groups, epsilon)
+
+            epsilon = T(1e-5)
+            x, scale, bias = _setup_groupnorm(T, sz, groups; track_stats=false)
+            @time y = _f(x, scale, bias)
+
+            @inferred groupnorm(x, scale, bias; groups, epsilon)
+            run_JET_tests(_f, x, scale, bias; opt_broken=true)
+            @test y isa Array{T, 4}
+            @test size(y) == sz
+
+            Zygote.gradient(sum ∘ _f, x, scale, bias)  # Compile
+            @time gs_x, gs_scale, gs_bias = Zygote.gradient(sum ∘ _f, x, scale, bias)
+
+            # Use the generic implementation to test the KA implementation
+            __f = (args...) -> _groupnorm_generic_fallback(args..., nothing, nothing,
+                                                           Val(true), T(0.9), epsilon,
+                                                           groups)
+            @time y_ = __f(x, scale, bias)
+
+            Zygote.gradient(sum ∘ __f, x, scale, bias)  # Compile
+            @time gs_x_, gs_scale_, gs_bias_ = Zygote.gradient(sum ∘ __f, x, scale, bias)
+
+            # The KA implementation reorders operations manually for maximal
+            # performance. Hence equality cannot be guaranteed.
+            @test isapprox(y, y_; atol=1.0f-3, rtol=1.0f-3)
+            @test isapprox(gs_x, gs_x_; atol=1.0f-3, rtol=1.0f-3)
+            @test isapprox(gs_scale, gs_scale_; atol=1.0f-3, rtol=1.0f-3)
+            @test isapprox(gs_bias, gs_bias_; atol=1.0f-3, rtol=1.0f-3)
+        end
+    end
+
+    if gpu_testing()
+        for T in (Float32, Float64),
+            sz in ((16, 16, 6, 4), (32, 32, 6, 4), (64, 64, 12, 4)),
+            groups in (2, 3)
+
+            println("GN_GPU: $T $(sz) $groups")
+
+            _f = (args...) -> groupnorm(args...; groups, epsilon)
+
+            epsilon = T(1e-5)
+            x, scale, bias = _setup_groupnorm(T, sz, groups; track_stats=false)
+
+            x, scale, bias = (x, scale, bias) .|> cu
+            x = x .|> T
+            scale = scale .|> T
+            bias = bias .|> T
+
+            CUDA.@time y = _f(x, scale, bias)
+
+            @inferred groupnorm(x, scale, bias; groups, epsilon)
+            run_JET_tests(_f, x, scale, bias; opt_broken=true, call_broken=true)
+            @test y isa CuArray{T, 4}
+            @test size(y) == sz
+
+            Zygote.gradient(sum ∘ _f, x, scale, bias)  # Compile
+            CUDA.@time gs_x, gs_scale, gs_bias = Zygote.gradient(sum ∘ _f, x, scale, bias)
+
+            # Use the generic implementation to test the KA implementation
+            __f = (args...) -> _groupnorm_generic_fallback(args..., nothing, nothing,
+                                                           Val(true), T(0.9), epsilon,
+                                                           groups)
+
+            CUDA.@time y_ = __f(x, scale, bias)
+
+            Zygote.gradient(sum ∘ __f, x, scale, bias)  # Compile
+            CUDA.@time gs_x_, gs_scale_, gs_bias_ = Zygote.gradient(sum ∘ __f, x, scale,
+                                                                    bias)
+
+            # The KA implementation reorders operations manually for maximal
+            # performance. Hence equality cannot be guaranteed.
+            @test isapprox(y, y_; atol=1.0f-3, rtol=1.0f-3)
+            @test isapprox(gs_x, gs_x_; atol=1.0f-3, rtol=1.0f-3)
+            @test isapprox(gs_scale, gs_scale_; atol=1.0f-3, rtol=1.0f-3)
+            @test isapprox(gs_bias, gs_bias_; atol=1.0f-3, rtol=1.0f-3)
+        end
+    end
+end
+
+@testset "GroupNorm Generic Fallback" begin
+    if cpu_testing()
+        for T in (Float16, Float32, Float64),
+            sz in ((4, 4, 6, 2), (8, 8, 6, 2), (16, 16, 12, 2)),
+            groups in (2, 3),
+            training in (Val(true), Val(false))
+
+            println("GN_CPU: $T $(sz) $groups $training")
+
+            _f = (args...) -> groupnorm(args...; groups, epsilon, training, momentum=T(0.9))
+
+            epsilon = T(1e-5)
+            x, scale, bias, rm, rv = _setup_groupnorm(T, sz, groups; track_stats=true)
+            @time y, nt = _f(x, scale, bias, rm, rv)
+
+            @inferred first(groupnorm(x, scale, bias, rm, rv; groups, epsilon, training,
+                                      momentum=T(0.9)))
+            run_JET_tests(_f, x, scale, bias, rm, rv; opt_broken=true)
+            @test y isa Array{T, 4}
+            @test size(y) == sz
+            @test size(nt.running_mean) == (groups,)
+            @test size(nt.running_var) == (groups,)
+
+            Zygote.gradient(sum ∘ first ∘ _f, x, scale, bias, rm, rv)  # Compile
+            @time gs_x, gs_scale, gs_bias, _, _ = Zygote.gradient(sum ∘ first ∘ _f, x,
+                                                                  scale, bias, rm, rv)
+
+            if T != Float16
+                __f = (args...) -> sum(first(groupnorm(args..., rm, rv; groups, epsilon,
+                                                       training, momentum=T(0.9))))
+                test_gradient_correctness_fdm(__f, x, scale, bias; atol=1.0f-2, rtol=1.0f-2)
+            end
+        end
+    end
+
+    if gpu_testing()
+        for T in (Float16, Float32, Float64),
+            sz in ((4, 4, 6, 2), (8, 8, 6, 2), (16, 16, 12, 2)),
+            groups in (2, 3),
+            training in (Val(true), Val(false))
+
+            println("GN_GPU: $T $(sz) $groups $training")
+
+            _f = (args...) -> groupnorm(args...; groups, epsilon, training, momentum=T(0.9))
+
+            epsilon = T(1e-5)
+            x, scale, bias, rm, rv = _setup_groupnorm(T, sz, groups; track_stats=true)
+
+            x, scale, bias, rm, rv = (x, scale, bias, rm, rv) .|> cu
+            x = x .|> T
+            scale = scale .|> T
+            bias = bias .|> T
+            rm = rm .|> T
+            rv = rv .|> T
+
+            CUDA.@time y, nt = _f(x, scale, bias, rm, rv)
+
+            @inferred first(groupnorm(x, scale, bias, rm, rv; groups, epsilon, training,
+                                      momentum=T(0.9)))
+            run_JET_tests(_f, x, scale, bias, rm, rv; opt_broken=true, call_broken=true)
+            @test y isa CuArray{T, 4}
+            @test size(y) == sz
+            @test size(nt.running_mean) == (groups,)
+            @test size(nt.running_var) == (groups,)
+
+            Zygote.gradient(sum ∘ first ∘ _f, x, scale, bias, rm, rv)  # Compile
+            CUDA.@time gs_x, gs_scale, gs_bias, _, _ = Zygote.gradient(sum ∘ first ∘ _f, x,
+                                                                       scale, bias, rm, rv)
+
+            __f = (args...) -> sum(first(groupnorm(args..., rm, rv; groups, epsilon,
+                                                   training, momentum=T(0.9))))
+            # FiniteDifferences for GPU seems broken
+            # test_gradient_correctness_fdm(__f, x, scale, bias; atol=1.0f-2, rtol=1.0f-2)
+        end
+    end
+end

--- a/lib/LuxLib/test/api/layernorm.jl
+++ b/lib/LuxLib/test/api/layernorm.jl
@@ -1,0 +1,101 @@
+using CUDA, Statistics, Test
+using LuxLib
+
+include("../test_utils.jl")
+
+function _setup_layernorm(T, x_size, affine_shape)
+    x = randn(T, x_size)
+    if affine_shape !== nothing
+        scale = randn(T, affine_shape..., 1)
+        bias = randn(T, affine_shape..., 1)
+        return x, scale, bias
+    else
+        return x, nothing, nothing
+    end
+end
+
+@testset "LayerNorm" begin
+    if cpu_testing()
+        for T in (Float16, Float32, Float64),
+            x_shape in ((3, 3, 2, 1), (2, 2, 2, 1), (2, 3, 2, 2)),
+            affine_shape in (nothing, x_shape[1:3], (1, 1, 1), (1, 1, x_shape[3]))
+
+            println("LN_CPU: $T $(x_shape) $(affine_shape)")
+
+            dims = Colon()
+            epsilon = T(1e-5)
+            _f = (args...) -> layernorm(args...; dims, epsilon)
+
+            x, scale, bias = _setup_layernorm(T, x_shape, affine_shape)
+
+            @inferred _f(x, scale, bias)
+
+            y = _f(x, scale, bias)
+
+            @test y isa Array{T, 4}
+            @test size(y) == x_shape
+
+            if affine_shape === nothing
+                @test isapprox(mean(y; dims), 0; atol=1e-3, rtol=1e-3)
+                @test isapprox(std(y; dims), 1; atol=1e-1, rtol=1e-1)
+            end
+
+            run_JET_tests(_f, x, scale, bias)
+
+            if T != Float16 # FDM is not ideal with Float16 values
+                if affine_shape === nothing
+                    test_gradient_correctness_fdm(x -> sum(_f(x, nothing, nothing)), x;
+                                                  atol=1.0f-2, rtol=1.0f-2)
+                else
+                    test_gradient_correctness_fdm(sum ∘ _f, x, scale, bias; atol=1.0f-2,
+                                                  rtol=1.0f-2)
+                end
+            end
+        end
+    end
+
+    if gpu_testing()
+        for T in (Float16, Float32, Float64),
+            x_shape in ((3, 3, 2, 1), (2, 2, 2, 1), (2, 3, 2, 2)),
+            affine_shape in (nothing, x_shape[1:3], (1, 1, 1), (1, 1, x_shape[3]))
+
+            println("LN_GPU: $T $(x_shape) $(affine_shape)")
+
+            dims = Colon()
+            epsilon = T(1e-5)
+            _f = (args...) -> layernorm(args...; dims, epsilon)
+
+            x, scale, bias = _setup_layernorm(T, x_shape, affine_shape)
+
+            x = x |> cu .|> T
+            if affine_shape !== nothing
+                scale = scale |> cu .|> T
+                bias = bias |> cu .|> T
+            end
+
+            @inferred _f(x, scale, bias)
+
+            y = _f(x, scale, bias)
+
+            @test y isa CuArray{T, 4}
+            @test size(y) == x_shape
+
+            if affine_shape === nothing
+                @test isapprox(mean(y; dims), 0; atol=1e-3, rtol=1e-3)
+                @test isapprox(std(y; dims), 1; atol=1e-1, rtol=1e-1)
+            end
+
+            run_JET_tests(_f, x, scale, bias; call_broken=true)
+
+            # if T != Float16 # FDM is not ideal with Float16 values
+            #     if affine_shape === nothing
+            #         test_gradient_correctness_fdm(x -> sum(_f(x, nothing, nothing)), x;
+            #                                       atol=1.0f-2, rtol=1.0f-2)
+            #     else
+            #         test_gradient_correctness_fdm(sum ∘ _f, x, scale, bias; atol=1.0f-2,
+            #                                       rtol=1.0f-2)
+            #     end
+            # end
+        end
+    end
+end

--- a/lib/LuxLib/test/runtests.jl
+++ b/lib/LuxLib/test/runtests.jl
@@ -1,0 +1,9 @@
+using SafeTestsets, Test
+
+@testset "LuxLib" begin
+    @time @safetestset "Dropout" begin include("api/dropout.jl") end
+
+    @time @safetestset "BatchNorm" begin include("api/batchnorm.jl") end
+    @time @safetestset "GroupNorm" begin include("api/groupnorm.jl") end
+    @time @safetestset "LayerNorm" begin include("api/layernorm.jl") end
+end

--- a/lib/LuxLib/test/test_utils.jl
+++ b/lib/LuxLib/test/test_utils.jl
@@ -1,0 +1,54 @@
+using CUDA, FiniteDifferences, JET, LuxLib, Test, Zygote
+
+const LUXLIB_TESTING_MODE = get(ENV, "LUXLIB_TESTING_MODE", :all)
+
+function cpu_testing()
+    return LUXLIB_TESTING_MODE == :all || LUXLIB_TESTING_MODE == :cpu
+end
+
+function gpu_testing()
+    return (LUXLIB_TESTING_MODE == :all || LUXLIB_TESTING_MODE == :gpu) && has_cuda()
+end
+
+function Base.isapprox(x, y; kwargs...)
+    @warn "`isapprox` is not defined for ($(typeof(x)), $(typeof(y))). Using `==` instead."
+    return x == y
+end
+
+function Base.isapprox(x::Tuple, y::Tuple; kwargs...)
+    return all(isapprox.(x, y; kwargs...))
+end
+
+function Base.isapprox(nt1::NamedTuple{fields}, nt2::NamedTuple{fields};
+                       kwargs...) where {fields}
+    checkapprox(xy) = isapprox(xy[1], xy[2]; kwargs...)
+    checkapprox(t::Tuple{Nothing, Nothing}) = true
+    return all(checkapprox, zip(values(nt1), values(nt2)))
+end
+
+function Base.isapprox(t1::NTuple{N, T}, t2::NTuple{N, T}; kwargs...) where {N, T}
+    checkapprox(xy) = isapprox(xy[1], xy[2]; kwargs...)
+    checkapprox(t::Tuple{Nothing, Nothing}) = true
+    return all(checkapprox, zip(t1, t2))
+end
+
+Base.isapprox(::Nothing, v::AbstractArray; kwargs...) = length(v) == 0
+Base.isapprox(v::AbstractArray, ::Nothing; kwargs...) = length(v) == 0
+
+# JET Tests
+function run_JET_tests(f, args...; call_broken=false, opt_broken=false, kwargs...)
+    @static if VERSION >= v"1.7"
+        test_call(f, typeof.(args); broken=call_broken)
+        test_opt(f, typeof.(args); broken=opt_broken, target_modules=(LuxLib,))
+    end
+end
+
+# Test the gradients generated using AD against the gradients generated using Finite
+# Differences
+function test_gradient_correctness_fdm(f::Function, args...; kwargs...)
+    gs_ad = Zygote.gradient(f, args...)
+    gs_fdm = FiniteDifferences.grad(FiniteDifferences.central_fdm(8, 1), f, args...)
+    for (g_ad, g_fdm) in zip(gs_ad, gs_fdm)
+        @test isapprox(g_ad, g_fdm; kwargs...)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ function activate_subpkg_env(subpkg)
 end
 
 groups = if GROUP == "All"
-    ["Lux", "Boltz"]
+    ["Lux", "Boltz", "LuxLib"]
 else
     [GROUP]
 end


### PR DESCRIPTION
# TODOs

- [x] Add the Normalization Layers
    - [x] GroupNorm (faster KA implementations with sensible fallbacks)
    - [x] BatchNorm
    - [x] LayerNorm
- [x] Dropout Layer
- [x] Testing
    - [x] GroupNorm
    - [x] BatchNorm
    - [x] LayerNorm
    - [x] Dropout
- [x] Hacky Backport for some of KA features to support julia 1.6
- [x] Documentation
- [x] README Badges

# Non-Goals

* Integrate with Lux.jl. This needs to be done once this PR is merged and is registered

# Notes

A partial solution to #10  and #98. Can close those once Lux starts depending on LuxLib